### PR TITLE
Fetch Core Resources Before Rendering

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';
 import { ZooHeader, ZooFooter } from 'zooniverse-react-components';
-
-import { fetchProject } from '../ducks/project';
+import { fetchResources } from '../ducks/initialize';
 
 import AboutLayout from './about';
 import AuthContainer from '../containers/AuthContainer';
@@ -15,10 +14,12 @@ import ProjectHeader from './ProjectHeader';
 
 class App extends React.Component {
   componentWillMount() {
-    this.props.dispatch(fetchProject());
+    this.props.dispatch(fetchResources());
   }
 
   render() {
+    if (!this.props.initializerReady) return null;
+
     return (
       <div>
         <header className="app-header">
@@ -49,6 +50,7 @@ class App extends React.Component {
 
 App.propTypes = {
   dialog: PropTypes.node,
+  initializerReady: PropTypes.bool,
   location: PropTypes.shape({
     pathname: PropTypes.string
   })
@@ -56,11 +58,13 @@ App.propTypes = {
 
 App.defaultProps = {
   dialog: null,
+  initializerReady: false,
   location: {}
 };
 
 const mapStateToProps = (state) => ({
-  dialog: state.dialog.data
+  dialog: state.dialog.data,
+  initializerReady: state.initialize.ready
 });
 
 export default connect(mapStateToProps)(App);

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { fetchGuide } from '../ducks/field-guide';
 import { toggleDialog } from '../ducks/dialog';
 import FieldGuide from '../components/FieldGuide';
 

--- a/src/components/Dialog.jsx
+++ b/src/components/Dialog.jsx
@@ -8,7 +8,6 @@ import { Utility } from '../lib/Utility';
 class Dialog extends React.Component {
   constructor(props) {
     super(props);
-    this.popupBody = null;
     this.close = this.close.bind(this);
   }
 
@@ -39,9 +38,7 @@ class Dialog extends React.Component {
         <div
           className="popup dialog"
           tabIndex="0"
-          ref={(c) => { this.popupBody = c; }}
           role="button"
-          onClick={(e) => { return e.target === this.popupBody && this.close(e); }}
         >
           <div className="dialog-content">
             <div>

--- a/src/ducks/field-guide.js
+++ b/src/ducks/field-guide.js
@@ -48,7 +48,7 @@ const fetchGuide = () => {
       type: FETCH_GUIDE
     });
 
-    apiClient.type('field_guides').get({ project_id: `${config.projectId}` }).then(([guide]) => {
+    return apiClient.type('field_guides').get({ project_id: `${config.projectId}` }).then(([guide]) => {
       const icons = {};
 
       if (guide) {

--- a/src/ducks/initialize.js
+++ b/src/ducks/initialize.js
@@ -1,0 +1,60 @@
+import { fetchProject } from './project';
+import { fetchWorkflow } from './workflow';
+import { fetchGuide } from './field-guide';
+
+const FETCH_RESOURCES = 'FETCH_RESOURCES';
+const FETCH_RESOURCES_SUCCESS = 'FETCH_RESOURCES_SUCCESS';
+const FETCH_RESOURCES_ERROR = 'FETCH_RESOURCES_ERROR';
+
+const INITIALIZER_STATUS = {
+  IDLE: 'initializer_status_idle',
+  FETCHING: 'initializer_status_fetching',
+  READY: 'initializer_status_ready',
+  ERROR: 'initializer_status_error'
+};
+
+// Reducer
+const initialState = {
+  ready: false,
+  status: INITIALIZER_STATUS.IDLE
+};
+
+const initializeReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case FETCH_RESOURCES:
+      return Object.assign({}, state, {
+        status: INITIALIZER_STATUS.FETCHING
+      });
+
+    case FETCH_RESOURCES_SUCCESS:
+      return {
+        status: INITIALIZER_STATUS.READY,
+        ready: true
+      };
+
+    default:
+      return state;
+  }
+};
+
+const fetchResources = () => {
+  return (dispatch) => {
+    dispatch({ type: FETCH_RESOURCES });
+
+    Promise.all([
+      dispatch(fetchProject()),
+      dispatch(fetchWorkflow()),
+      dispatch(fetchGuide())
+    ]).then(() => {
+      dispatch({ type: FETCH_RESOURCES_SUCCESS });
+    }).catch(() => {
+      dispatch({ type: FETCH_RESOURCES_ERROR });
+    });
+  };
+};
+
+export default initializeReducer;
+
+export {
+  fetchResources
+};

--- a/src/ducks/login.js
+++ b/src/ducks/login.js
@@ -13,15 +13,25 @@ const loginReducer = (state = initialState, action) => {
   switch (action.type) {
     case SET_LOGIN_USER:
       return {
-        user: action.user,  // null if logged out.
-        initialised: true,  // true once we know if user is logged in/out; false if unknown.
+        user: action.user,
+        initialised: true
       };
+
     default:
       return state;
-  };
+  }
 };
 
 // Action Creators
+const setLoginUser = (user) => {
+  return (dispatch) => {
+    dispatch({
+      type: SET_LOGIN_USER,
+      user
+    });
+  };
+};
+
 const checkLoginUser = () => {
   // First thing on app load - check if the user is logged in.
   return (dispatch) => {
@@ -33,7 +43,6 @@ const checkLoginUser = () => {
 };
 
 const loginToPanoptes = () => {
-  // Returns a login page URL for the user to navigate to.
   return (() => oauth.signIn(computeRedirectURL(window)));
 };
 
@@ -46,15 +55,6 @@ const logoutFromPanoptes = () => {
   };
 };
 
-const setLoginUser = (user) => {
-  return (dispatch) => {
-    dispatch({
-      type: SET_LOGIN_USER,
-      user,
-    });
-  };
-};
-
 // Helper functions
 const computeRedirectURL = (window) => {
   const { location } = window;
@@ -62,7 +62,6 @@ const computeRedirectURL = (window) => {
     `${location.protocol}//${location.hostname}:${location.port}`;
 };
 
-// Exports
 export default loginReducer;
 
 export {

--- a/src/ducks/project.js
+++ b/src/ducks/project.js
@@ -10,57 +10,58 @@ const PROJECT_STATUS = {
   IDLE: 'project_status_idle',
   FETCHING: 'project_status_fetching',
   READY: 'project_status_ready',
-  ERROR: 'project_status_error',
+  ERROR: 'project_status_error'
 };
 
 // Reducer
 const initialState = {
   data: null,
-  status: PROJECT_STATUS.IDLE,
+  status: PROJECT_STATUS.IDLE
 };
 
 const projectReducer = (state = initialState, action) => {
   switch (action.type) {
     case FETCH_PROJECT:
       return Object.assign({}, state, {
-        status: PROJECT_STATUS.FETCHING,
+        status: PROJECT_STATUS.FETCHING
       });
 
     case FETCH_PROJECT_SUCCESS:
       return {
         status: PROJECT_STATUS.READY,
-        data: action.data,
+        data: action.data
       };
 
     case FETCH_PROJECT_ERROR:
       return Object.assign({}, state, {
-        status: PROJECT_STATUS.ERROR,
+        status: PROJECT_STATUS.ERROR
       });
 
     default:
       return state;
-  };
+  }
 };
 
 const fetchProject = (id = config.projectId) => {
   return (dispatch) => {
     dispatch({ type: FETCH_PROJECT });
 
-    apiClient.type('projects').get(id)
+    return apiClient.type('projects').get(id)
       .then((project) => {
         dispatch({
           type: FETCH_PROJECT_SUCCESS,
           data: project
         });
       })
-      .catch((err) => {
+      .catch(() => {
         dispatch({ type: FETCH_PROJECT_ERROR });
-      })
+      });
   };
 };
 
 export default projectReducer;
 
 export {
-  fetchProject
+  fetchProject,
+  PROJECT_STATUS
 };

--- a/src/ducks/reducer.js
+++ b/src/ducks/reducer.js
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux';
 import dialog from './dialog';
 import fieldGuide from './field-guide';
+import initialize from './initialize';
 import login from './login';
 import project from './project';
 import subject from './subject';
@@ -10,6 +11,7 @@ import workflow from './workflow';
 export default combineReducers({
   dialog,
   fieldGuide,
+  initialize,
   login,
   project,
   subject,

--- a/src/ducks/workflow.js
+++ b/src/ducks/workflow.js
@@ -3,37 +3,70 @@ import { config } from '../config';
 
 // Action Types
 const FETCH_WORKFLOW = 'FETCH_WORKFLOW';
+const FETCH_WORKFLOW_SUCCESS = 'FETCH_PROJECT_SUCCESS';
+const FETCH_WORKFLOW_ERROR = 'FETCH_WORKFLOW_ERROR';
+
+const WORKFLOW_STATUS = {
+  IDLE: 'workflow_status_idle',
+  FETCHING: 'workflow_status_fetching',
+  READY: 'workflow_status_ready',
+  ERROR: 'workflow_status_error'
+};
 
 // Reducer
 const initialState = {
   data: null,
+  id: null,
+  status: WORKFLOW_STATUS.IDLE
 };
 
 const workflowReducer = (state = initialState, action) => {
   switch (action.type) {
     case FETCH_WORKFLOW:
-      return {
-        data: action.data,
-      };
+      return Object.assign({}, state, {
+        status: WORKFLOW_STATUS.FETCHING,
+        id: action.id
+      });
+
+    case FETCH_WORKFLOW_SUCCESS:
+      return Object.assign({}, state, {
+        status: WORKFLOW_STATUS.READY,
+        data: action.data
+      });
+
+    case FETCH_WORKFLOW_ERROR:
+      return Object.assign({}, state, {
+        status: WORKFLOW_STATUS.ERROR
+      });
+
     default:
       return state;
-  };
+  }
 };
 
 const fetchWorkflow = (id = config.workflowId) => {
   return (dispatch) => {
-    apiClient.type('workflows').get(id)
+    dispatch({
+      type: FETCH_WORKFLOW,
+      id
+    });
+
+    return apiClient.type('workflows').get(id)
       .then((workflow) => {
         dispatch({
-          type: FETCH_PROJECT,
+          type: FETCH_WORKFLOW_SUCCESS,
           data: workflow
         });
       })
+      .catch(() => {
+        dispatch({ type: FETCH_WORKFLOW_ERROR });
+      });
   };
 };
 
 export default workflowReducer;
 
 export {
-  fetchWorkflow
+  fetchWorkflow,
+  WORKFLOW_STATUS
 };


### PR DESCRIPTION
COOL! I think I did this right, and I'm pretty happy with how it has cleaned everything up. This PR abstracts all the core resources out to an initializer duck before rendering anything.

Let me know if something looks out of place here. It might be redundant to have an `initializerReady` prop as well as `INITIALIZER_STATUS` and also `login.initialized` (sp?) in another part of the code? Also, British "initialised" vs. American "initialized."

Also, some of these lines are general clean up with some of the ducks and removal of the unnecessary `popupbody` ref.