### PR TITLE
Create Annotation Tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/zooniverse/scribes-of-the-cairo-geniza",
   "dependencies": {
+    "counterpart": "^0.18.1",
     "history": "~4.6.3",
     "markdownz": "~7.3.1",
     "panoptes-client": "~2.8.0",

--- a/src/components/AnnotationsPane.jsx
+++ b/src/components/AnnotationsPane.jsx
@@ -4,10 +4,6 @@ import { connect } from 'react-redux';
 import { Utility } from '../lib/Utility';
 
 class AnnotationsPane extends React.Component {
-  constructor(props) {
-    super(props);
-  }
-
   renderAnnotationInProgress() {
     if (!this.props.annotationInProgress) return null;
 
@@ -33,7 +29,7 @@ class AnnotationsPane extends React.Component {
     );
   }
 
-  renderAnnotations(annotations) {
+  renderAnnotations() {
     if (!this.props.annotations.length) return null;
 
     const annotationPrefix = 'ANNOTATION_';
@@ -41,8 +37,8 @@ class AnnotationsPane extends React.Component {
     return this.props.annotations.map((annotation, index) => {
       if (annotation.frame !== this.props.frame) return null;
 
-      let onSelectAnnotation = this.props.onSelectAnnotation;
-      let svgPointPrefix = `ANNOTATION_${index}_POINT_`;
+      const onSelectAnnotation = this.props.onSelectAnnotation;
+      const svgPointPrefix = `ANNOTATION_${index}_POINT_`;
       const svgPoints = [];
 
       for (let i = 0; i < 2; i += 1) {
@@ -99,12 +95,21 @@ AnnotationsPane.propTypes = {
       y: PropTypes.number
     }))
   }),
-  annotations: PropTypes.arrayOf(PropTypes.object)
+  annotations: PropTypes.arrayOf(PropTypes.object),
+  imageSize: PropTypes.shape({
+    height: PropTypes.number,
+    width: PropTypes.number
+  }),
+  frame: PropTypes.number,
+  onSelectAnnotation: PropTypes.func
 };
 
 AnnotationsPane.defaultProps = {
   annotationInProgress: null,
-  annotations: []
+  annotations: [],
+  imageSize: {},
+  frame: 0,
+  onSelectAnnotation: () => {}
 };
 
 export default connect()(AnnotationsPane);

--- a/src/components/AnnotationsPane.jsx
+++ b/src/components/AnnotationsPane.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Utility } from '../lib/Utility';
+
+class AnnotationsPane extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  renderAnnotationInProgress() {
+    if (!this.props.annotationInProgress) return null;
+
+    const svgPointPrefix = 'ANNOTATION_IN_PROGRESS_POINT_';
+    const svgPoints = [];
+
+    for (let i = 0; i < this.props.annotationInProgress.points.length; i += 1) {
+      const point = this.props.annotationInProgress.points[i];
+      svgPoints.push(
+        <circle
+          key={svgPointPrefix + i}
+          cx={point.x}
+          cy={point.y}
+          r={10}
+          fill="#20FECB"
+        />,
+      );
+    }
+    return (
+      <g className="annotation-in-progress">
+        {svgPoints}
+      </g>
+    );
+  }
+
+  renderAnnotations(annotations) {
+    if (!this.props.annotations.length) return null;
+
+    const annotationPrefix = 'ANNOTATION_';
+
+    return this.props.annotations.map((annotation, index) => {
+      if (annotation.frame !== this.props.frame) return null;
+
+      let onSelectAnnotation = this.props.onSelectAnnotation;
+      let svgPointPrefix = `ANNOTATION_${index}_POINT_`;
+      const svgPoints = [];
+
+      for (let i = 0; i < 2; i += 1) {
+        const point = annotation.points[i];
+
+        svgPoints.push(
+          <circle
+            key={svgPointPrefix + i}
+            cx={point.x}
+            cy={point.y}
+            r={10}
+            fill="#20FECB"
+          />,
+        );
+      }
+
+      return (
+        <g
+          className="annotation"
+          key={annotationPrefix + index}
+          onClick={(e) => {
+            if (onSelectAnnotation) {
+              onSelectAnnotation(index);
+            }
+            return Utility.stopEvent(e);
+          }}
+          onMouseMove={e => Utility.stopEvent(e)}
+          onMouseDown={e => Utility.stopEvent(e)}
+          onMouseUp={e => Utility.stopEvent(e)}
+        >
+          {svgPoints}
+        </g>
+      );
+    });
+  }
+
+  render() {
+    const imageOffset = `translate(${-this.props.imageSize.width / 2}, ${-this.props.imageSize.height / 2})`;
+
+    return (
+      <g transform={imageOffset}>
+        {this.renderAnnotationInProgress()}
+        {this.renderAnnotations()}
+      </g>
+    );
+  }
+}
+
+AnnotationsPane.propTypes = {
+  annotationInProgress: PropTypes.shape({
+    text: PropTypes.string,
+    points: PropTypes.arrayOf(PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number
+    }))
+  }),
+  annotations: PropTypes.arrayOf(PropTypes.object)
+};
+
+AnnotationsPane.defaultProps = {
+  annotationInProgress: null,
+  annotations: []
+};
+
+export default connect()(AnnotationsPane);

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+class SelectedAnnotation extends React.Component {
+  render() {
+    return (
+      <div>
+        <h1>hello world</h1>
+      </div>
+    );
+  }
+}
+
+export default SelectedAnnotation;

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -56,8 +56,18 @@ class Toolbar extends React.Component {
   render() {
     return (
       <section className="toolbar">
-        <button onClick={this.useAnnotationTool}>&#x02A01;</button>
-        <button onClick={this.useNavigationTool}><i className="fa fa-arrows" /></button>
+        <button
+          className={(this.props.viewerState === SUBJECTVIEWER_STATE.ANNOTATING) ? 'active' : ''}
+          onClick={this.useAnnotationTool}
+        >
+          &#x02A01;
+        </button>
+        <button
+          className={(this.props.viewerState === SUBJECTVIEWER_STATE.NAVIGATING) ? 'active' : ''}
+          onClick={this.useNavigationTool}
+        >
+          <i className="fa fa-arrows" />
+        </button>
 
         <hr />
 
@@ -81,18 +91,24 @@ class Toolbar extends React.Component {
 Toolbar.propTypes = {
   dispatch: PropTypes.func,
   rotation: PropTypes.number,
-  scaling: PropTypes.number
+  scaling: PropTypes.number,
+  viewerState: PropTypes.string
 };
 
 Toolbar.defaultProps = {
   dispatch: () => {},
   rotation: 0,
-  scaling: 0
+  scaling: 0,
+  viewerState: SUBJECTVIEWER_STATE.NAVIGATING
 };
 
-const mapStateToProps = (state) => ({
-  rotation: state.subjectViewer.rotation,
-  scaling: state.subjectViewer.scaling
-});
+const mapStateToProps = (state) => {
+  const sv = state.subjectViewer;
+  return {
+    rotation: sv.rotation,
+    scaling: sv.scaling,
+    viewerState: sv.viewerState
+  };
+};
 
 export default connect(mapStateToProps)(Toolbar);

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -1,12 +1,12 @@
- import React from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { setScaling, resetView,
   setRotation, toggleContrast,
-  // setTranslation,
-  // setViewerState, updateViewerSize, updateImageSize,
-  // SUBJECTVIEWER_STATE,
+  setViewerState,
+  // setTranslation, updateViewerSize, updateImageSize,
+  SUBJECTVIEWER_STATE
 } from '../ducks/subject-viewer';
 
 const ROTATION_STEP = 90;
@@ -21,6 +21,8 @@ class Toolbar extends React.Component {
     this.rotateSubject = this.rotateSubject.bind(this);
     this.resetView = this.resetView.bind(this);
     this.invertColors = this.invertColors.bind(this);
+    this.useAnnotationTool = this.useAnnotationTool.bind(this);
+    this.useNavigationTool = this.useNavigationTool.bind(this);
   }
 
   useZoomIn() {
@@ -43,11 +45,19 @@ class Toolbar extends React.Component {
     this.props.dispatch(toggleContrast());
   }
 
+  useAnnotationTool() {
+    this.props.dispatch(setViewerState(SUBJECTVIEWER_STATE.ANNOTATING));
+  }
+
+  useNavigationTool() {
+    this.props.dispatch(setViewerState(SUBJECTVIEWER_STATE.NAVIGATING));
+  }
+
   render() {
     return (
       <section className="toolbar">
-        <button>&#x02A01;</button>
-        <button><i className="fa fa-arrows" /></button>
+        <button onClick={this.useAnnotationTool}>&#x02A01;</button>
+        <button onClick={this.useNavigationTool}><i className="fa fa-arrows" /></button>
 
         <hr />
 

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -43,6 +43,7 @@ class SubjectViewer extends React.Component {
     this.onMouseMove = this.onMouseMove.bind(this);
     this.getPointerXY = this.getPointerXY.bind(this);
     this.getPointerXYOnImage = this.getPointerXYOnImage.bind(this);
+    this.onSelectAnnotation = this.onSelectAnnotation.bind(this);
 
     this.pointer = {
       start: { x: 0, y: 0 },
@@ -69,6 +70,16 @@ class SubjectViewer extends React.Component {
     window.removeEventListener('resize', this.updateSize);
   }
 
+  onImageLoad() {
+    if (this.svgImage && this.svgImage.image) {
+      const imgW = (this.svgImage.image.width) ? this.svgImage.image.width : 1;
+      const imgH = (this.svgImage.image.height) ? this.svgImage.image.height : 1;
+
+      this.props.dispatch(updateImageSize(imgW, imgH));
+      this.props.dispatch(resetView());
+    }
+  }
+
   updateSize() {
     if (!this.section || !this.svg) return;
 
@@ -83,16 +94,6 @@ class SubjectViewer extends React.Component {
     const svgW = boundingBox.width;
     const svgH = boundingBox.height;
     this.props.dispatch(updateViewerSize(svgW, svgH));
-  }
-
-  onImageLoad() {
-    if (this.svgImage && this.svgImage.image) {
-      const imgW = (this.svgImage.image.width) ? this.svgImage.image.width : 1;
-      const imgH = (this.svgImage.image.height) ? this.svgImage.image.height : 1;
-
-      this.props.dispatch(updateImageSize(imgW, imgH));
-      this.props.dispatch(resetView());
-    }
   }
 
   onImageError() {
@@ -216,6 +217,10 @@ class SubjectViewer extends React.Component {
     return Utility.stopEvent(e);
   }
 
+  onSelectAnnotation() {
+    this.props.dispatch(toggleDialog(<SelectedAnnotation />));
+  }
+
   render() {
     const transform = `scale(${this.props.scaling}) translate(${this.props.translationX}, ${this.props.translationY}) rotate(${this.props.rotation}) `;
     const cursor = this.props.viewerState === SUBJECTVIEWER_STATE.NAVIGATING ? 'cursor-move' : 'cursor-crosshairs';
@@ -307,9 +312,6 @@ SubjectViewer.propTypes = {
   translationY: PropTypes.number,
   scaling: PropTypes.number,
   subjectStatus: PropTypes.string,
-  user: PropTypes.shape({
-    id: PropTypes.string
-  }),
   viewerSize: PropTypes.shape({
     width: PropTypes.number,
     height: PropTypes.number
@@ -330,8 +332,10 @@ SubjectViewer.defaultProps = {
   subjectStatus: '',
   translationX: 0,
   translationY: 0,
-  user: null,
-  viewerSize: { width: 0, height: 0 },
+  viewerSize: {
+    width: 0,
+    height: 0
+  },
   viewerState: SUBJECTVIEWER_STATE.NAVIGATING
 };
 
@@ -349,7 +353,6 @@ const mapStateToProps = (state) => {
     subjectStatus: state.subject.status,
     translationX: sv.translationX,
     translationY: sv.translationY,
-    user: state.login.user,
     viewerSize: sv.viewerSize,
     viewerState: sv.viewerState
   };

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -41,6 +41,7 @@ class SubjectViewer extends React.Component {
     this.onMouseDown = this.onMouseDown.bind(this);
     this.onMouseUp = this.onMouseUp.bind(this);
     this.onMouseMove = this.onMouseMove.bind(this);
+    this.onMouseLeave = this.onMouseLeave.bind(this);
     this.getPointerXY = this.getPointerXY.bind(this);
     this.getPointerXYOnImage = this.getPointerXYOnImage.bind(this);
     this.onSelectAnnotation = this.onSelectAnnotation.bind(this);
@@ -199,6 +200,13 @@ class SubjectViewer extends React.Component {
     return Utility.stopEvent(e);
   }
 
+  onMouseLeave(e) {
+    if (this.props.viewerState === SUBJECTVIEWER_STATE.NAVIGATING) {
+      this.pointer.state = INPUT_STATE.IDLE;
+      return Utility.stopEvent(e);
+    }
+  }
+
   onMouseMove(e) {
     if (this.props.viewerState === SUBJECTVIEWER_STATE.NAVIGATING) {
       const pointerXY = this.getPointerXY(e);
@@ -245,6 +253,7 @@ class SubjectViewer extends React.Component {
           onMouseDown={this.onMouseDown}
           onMouseUp={this.onMouseUp}
           onMouseMove={this.onMouseMove}
+          onMouseLeave={this.onMouseLeave}
         >
           <g transform={transform}>
             {subjectLocation && (

--- a/src/ducks/annotations.js
+++ b/src/ducks/annotations.js
@@ -16,17 +16,18 @@ const initialState = {
 
 const annotationsReducer = (state = initialState, action) => {
   switch (action.type) {
-    case ADD_ANNOTATION_POINT:
+    case ADD_ANNOTATION_POINT: {
       const annotationInProgress = (state.annotationInProgress)
-        ? Object.assign({}, state.annotationInProgress) //Create a copy, don't modify the existing object.
-        : { details: [{value: ''}], points: [], frame: action.frame };
+        ? Object.assign({}, state.annotationInProgress)
+        : { details: [{ value: '' }], points: [], frame: action.frame };
       annotationInProgress.points.push({ x: action.x, y: action.y });
       return Object.assign({}, state, {
         status: ANNOTATION_STATUS.IN_PROGRESS,
         annotationInProgress
       });
+    }
 
-    case COMPLETE_ANNOTATION:
+    case COMPLETE_ANNOTATION: {
       const annotations = (state.annotations)
         ? state.annotations.splice(0)
         : [];
@@ -38,6 +39,7 @@ const annotationsReducer = (state = initialState, action) => {
         selectedAnnotation: state.annotationInProgress,
         selectedAnnotationIndex: annotations.length - 1
       });
+    }
 
     default:
       return state;
@@ -48,7 +50,9 @@ const addAnnotationPoint = (x, y, frame) => {
   return (dispatch) => {
     dispatch({
       type: ADD_ANNOTATION_POINT,
-      x, y, frame
+      x,
+      y,
+      frame
     });
   };
 };

--- a/src/ducks/annotations.js
+++ b/src/ducks/annotations.js
@@ -1,0 +1,68 @@
+const ADD_ANNOTATION_POINT = 'ADD_ANNOTATION_POINT';
+const COMPLETE_ANNOTATION = 'COMPLETE_ANNOTATION';
+
+const ANNOTATION_STATUS = {
+  IDLE: 'annotation_status_idle',
+  IN_PROGRESS: 'annotation_status_in_progress'
+};
+
+const initialState = {
+  annotationInProgress: null,
+  annotationPanePosition: null,
+  annotations: [],
+  selectedAnnotation: null,
+  status: ANNOTATION_STATUS.IDLE
+};
+
+const annotationsReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case ADD_ANNOTATION_POINT:
+      const annotationInProgress = (state.annotationInProgress)
+        ? Object.assign({}, state.annotationInProgress) //Create a copy, don't modify the existing object.
+        : { details: [{value: ''}], points: [], frame: action.frame };
+      annotationInProgress.points.push({ x: action.x, y: action.y });
+      return Object.assign({}, state, {
+        status: ANNOTATION_STATUS.IN_PROGRESS,
+        annotationInProgress
+      });
+
+    case COMPLETE_ANNOTATION:
+      const annotations = (state.annotations)
+        ? state.annotations.splice(0)
+        : [];
+      annotations.push(state.annotationInProgress);
+      return Object.assign({}, state, {
+        status: ANNOTATION_STATUS.IDLE,
+        annotationInProgress: null,
+        annotations,
+        selectedAnnotation: state.annotationInProgress,
+        selectedAnnotationIndex: annotations.length - 1
+      });
+
+    default:
+      return state;
+  }
+};
+
+const addAnnotationPoint = (x, y, frame) => {
+  return (dispatch) => {
+    dispatch({
+      type: ADD_ANNOTATION_POINT,
+      x, y, frame
+    });
+  };
+};
+
+const completeAnnotation = () => {
+  return (dispatch) => {
+    dispatch({
+      type: COMPLETE_ANNOTATION
+    });
+  };
+};
+
+export default annotationsReducer;
+
+export {
+  addAnnotationPoint, completeAnnotation
+};

--- a/src/ducks/classification.js
+++ b/src/ducks/classification.js
@@ -1,0 +1,84 @@
+import apiClient from 'panoptes-client/lib/api-client';
+import counterpart from 'counterpart';
+import { config } from '../config';
+
+const SUBMIT_CLASSIFICATION = 'SUBMIT_CLASSIFICATION';
+const SUBMIT_CLASSIFICATION_FINISHED = 'SUBMIT_CLASSIFICATION_FINISHED';
+const CREATE_CLASSIFICATION = 'CREATE_CLASSIFICATION';
+
+const CLASSIFICATION_STATUS = {
+  IDLE: 'classification_status_idle',
+  SENDING: 'classification_status_sending',
+  SUCCESS: 'classification_status_success',
+  ERROR: 'classification_status_error'
+};
+
+const initialState = {
+  classification: null,
+  status: CLASSIFICATION_STATUS.status
+};
+
+const classificationReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case CREATE_CLASSIFICATION:
+      return Object.assign({}, state, {
+        classification: action.classification,
+        status: CLASSIFICATION_STATUS.IDLE,
+        subjectCompletionAnswers: {}
+      });
+
+    case SUBMIT_CLASSIFICATION:
+      return Object.assign({}, state, {
+        status: CLASSIFICATION_STATUS.SENDING
+      });
+
+    case SUBMIT_CLASSIFICATION_FINISHED:
+      return Object.assign({}, state, {
+        classification: null,
+        status: CLASSIFICATION_STATUS.IDLE,
+        subjectCompletionAnswers: {}
+      });
+
+    default:
+      return state;
+  }
+};
+
+const createClassification = (subject) => {
+  return (dispatch, getState) => {
+    let workflow_version = '';
+    if (getState().workflow.data) {
+      workflow_version = getState().workflow.data.version;
+    }
+
+    const classification = apiClient.type('classifications').create({
+      annotations: [],
+      metadata: {
+        workflow_version,
+        started_at: (new Date()).toISOString(),
+        user_agent: navigator.userAgent,
+        user_language: counterpart.getLocale(),
+        utc_offset: ((new Date()).getTimezoneOffset() * 60).toString(),
+        subject_dimensions: []
+      },
+      links: {
+        project: config.projectId,
+        workflow: getState().workflow.id,
+        subjects: [subject.id]
+      }
+    });
+    classification._workflow = getState().workflow.data;
+    classification._subjects = [getState().subject.currentSubject];
+
+    dispatch({
+      type: CREATE_CLASSIFICATION,
+      classification
+    });
+  };
+};
+
+export default classificationReducer;
+
+export {
+  createClassification
+};

--- a/src/ducks/reducer.js
+++ b/src/ducks/reducer.js
@@ -8,8 +8,12 @@ import subject from './subject';
 import subjectViewer from './subject-viewer';
 import tutorial from './tutorial';
 import workflow from './workflow';
+import classification from './classification';
+import annotations from './annotations';
 
 export default combineReducers({
+  annotations,
+  classification,
   dialog,
   fieldGuide,
   initialize,

--- a/src/ducks/subject-viewer.js
+++ b/src/ducks/subject-viewer.js
@@ -2,9 +2,8 @@ const MIN_SCALING = 0.1;
 const MAX_SCALING = 10;
 
 const SUBJECTVIEWER_STATE = {
-  IDLE: 'idle',
-  NAVIGATING: 'navigating',
-  ANNOTATING: 'annotating'
+  ANNOTATING: 'annotating',
+  NAVIGATING: 'navigating'
 };
 
 const initialState = {
@@ -24,6 +23,7 @@ const SET_ROTATION = 'SET_ROTATION';
 const SET_SCALING = 'SET_SCALING';
 const SET_TRANSLATION = 'SET_TRANSLATION';
 const TOGGLE_CONTRAST = 'TOGGLE_CONTRAST';
+const SET_VIEWER_STATE = 'SET_VIEWER_STATE';
 const UPDATE_IMAGE_SIZE = 'UPDATE_IMAGE_SIZE';
 const UPDATE_VIEWER_SIZE = 'UPDATE_VIEWER_SIZE';
 
@@ -80,14 +80,18 @@ const subjectViewerReducer = (state = initialState, action) => {
       });
     }
 
-    case UPDATE_IMAGE_SIZE: {
+    case SET_VIEWER_STATE:
+      return Object.assign({}, state, {
+        viewerState: action.viewerState
+      });
+
+    case UPDATE_IMAGE_SIZE:
       return Object.assign({}, state, {
         imageSize: {
           width: action.width,
           height: action.height
         }
       });
-    }
 
     case UPDATE_VIEWER_SIZE: {
       let bestFitScaled = 1;
@@ -118,6 +122,24 @@ const resetView = () => {
   return (dispatch) => {
     dispatch({
       type: RESET_VIEW
+    });
+  };
+};
+
+const setTranslation = (x, y) => {
+  return (dispatch) => {
+    dispatch({
+      type: SET_TRANSLATION,
+      x, y
+    });
+  };
+};
+
+const setViewerState = (viewerState) => {
+  return (dispatch) => {
+    dispatch({
+      type: SET_VIEWER_STATE,
+      viewerState
     });
   };
 };
@@ -168,15 +190,6 @@ const toggleContrast = () => {
   };
 };
 
-const setTranslation = (x, y) => {
-  return (dispatch) => {
-    dispatch({
-      type: SET_TRANSLATION,
-      x, y
-    });
-  };
-};
-
 export default subjectViewerReducer;
 
 export {
@@ -185,6 +198,7 @@ export {
   setScaling,
   setTranslation,
   toggleContrast,
+  setViewerState,
   updateImageSize,
   updateViewerSize,
   SUBJECTVIEWER_STATE

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -1,5 +1,6 @@
 import apiClient from 'panoptes-client/lib/api-client';
 import { config } from '../config';
+import { createClassification } from './classification';
 
 // Action Types
 const FETCH_SUBJECT = 'FETCH_SUBJECT';
@@ -44,6 +45,10 @@ const subjectReducer = (state = initialState, action) => {
   }
 };
 
+const prepareForNewSubject = (dispatch, subject) => {
+  dispatch(createClassification(subject));
+};
+
 const fetchQueue = (id = config.workflowId) => {
   return (dispatch) => {
     dispatch({
@@ -58,6 +63,7 @@ const fetchQueue = (id = config.workflowId) => {
           type: FETCH_SUBJECT_SUCCESS,
           queue
         });
+        prepareForNewSubject(dispatch, currentSubject);
       })
       .catch(() => {
         dispatch({ type: FETCH_SUBJECT_ERROR });
@@ -68,6 +74,10 @@ const fetchQueue = (id = config.workflowId) => {
 const subjectError = () => {
   return (dispatch) => {
     dispatch({ type: FETCH_SUBJECT_ERROR });
+      .catch((err) => {
+        console.error('ducks/subject.js fetchSubject() error: ', err);
+        dispatch({ type: FETCH_SUBJECT_ERROR });
+      });
   };
 };
 

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -29,11 +29,11 @@ const subjectReducer = (state = initialState, action) => {
       });
 
     case FETCH_SUBJECT_SUCCESS:
-      return {
+      return Object.assign({}, state, {
         queue: action.queue,
         currentSubject: action.currentSubject,
         status: SUBJECT_STATUS.READY
-      };
+      });
 
     case FETCH_SUBJECT_ERROR:
       return Object.assign({}, state, {
@@ -65,7 +65,8 @@ const fetchQueue = (id = config.workflowId) => {
         });
         prepareForNewSubject(dispatch, currentSubject);
       })
-      .catch(() => {
+      .catch((err) => {
+        console.error('ducks/subject.js fetchSubject() error: ', err);
         dispatch({ type: FETCH_SUBJECT_ERROR });
       });
   };
@@ -74,10 +75,6 @@ const fetchQueue = (id = config.workflowId) => {
 const subjectError = () => {
   return (dispatch) => {
     dispatch({ type: FETCH_SUBJECT_ERROR });
-      .catch((err) => {
-        console.error('ducks/subject.js fetchSubject() error: ', err);
-        dispatch({ type: FETCH_SUBJECT_ERROR });
-      });
   };
 };
 

--- a/src/styles/components/dialog.styl
+++ b/src/styles/components/dialog.styl
@@ -33,7 +33,6 @@
     overflow: auto
 
     > div:first-child
-      background-color: $bisque
       position: fixed
       width: 100%
       z-index: 1

--- a/src/styles/components/subject-viewer.styl
+++ b/src/styles/components/subject-viewer.styl
@@ -23,8 +23,8 @@
         &:hover, &:focus
           color: $bisque
 
-.cursor-move
-  cursor: move
+  &.cursor-move
+    cursor: move
 
-.cursor-crosshairs
-  cursor: crosshair
+  &.cursor-crosshairs
+    cursor: crosshair

--- a/src/styles/components/toolbar.styl
+++ b/src/styles/components/toolbar.styl
@@ -28,7 +28,7 @@
     padding: 0.25rem
     width: 1.75rem
 
-    &:hover, &:focus
+    &:hover, &:focus, &.active
       border-color: $sand
       background-color: $sand
       border-radius: 50%

--- a/src/styles/global/app-theme.styl
+++ b/src/styles/global/app-theme.styl
@@ -7,6 +7,7 @@ $light-teal = #ADDDE0
 $thistle = #C6B9B8
 $light-grey = #D6DEE4
 $mid-grey = #979797
+$gak-green = #20FECB
 
 $merriweather = 'Merriweather', serif;
 $work-sans = 'Work Sans', sans-serif;


### PR DESCRIPTION
This PR could do a million more lines, but I've stopped it at this point to keep it from getting too large. Currently, this branch will create and store annotations, place those annotations in the Redux store, and open an annotation window. 

This branch does not save text or delete annotations. That functionality is best saved for a future PR to break things up. I would also like to combine a lot of the functionality between classifications and annotations (mainly updating the classification as annotations are stored and deleted), but I am going to wait on that work until after this is merged. 

There is also some information here such as storing some workflow info in a classification that returns `undefined` now but should be more functional once another current PR is merged. 