### PR TITLE
Add Touch events to Subject Viewer

### DIFF
--- a/src/components/AnnotationsPane.jsx
+++ b/src/components/AnnotationsPane.jsx
@@ -65,9 +65,8 @@ class AnnotationsPane extends React.Component {
             }
             return Utility.stopEvent(e);
           }}
-          onMouseMove={e => Utility.stopEvent(e)}
           onMouseDown={e => Utility.stopEvent(e)}
-          onMouseUp={e => Utility.stopEvent(e)}
+          onTouchStart={e => Utility.stopEvent(e)}
         >
           {svgPoints}
         </g>

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -254,6 +254,10 @@ class SubjectViewer extends React.Component {
           onMouseUp={this.onMouseUp}
           onMouseMove={this.onMouseMove}
           onMouseLeave={this.onMouseLeave}
+          onTouchStart={this.onMouseDown}
+          onTouchEnd={this.onMouseUp}
+          onTouchMove={this.onMouseMove}
+          onTouchCancel ={this.onMouseLeave}
         >
           <g transform={transform}>
             {subjectLocation && (

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -119,6 +119,12 @@ class SubjectViewer extends React.Component {
         e.touches[0].clientY) {
       clientX = e.touches[0].clientX;
       clientY = e.touches[0].clientY;
+    } else if (e.changedTouches && e.changedTouches.length > 0 &&
+        e.changedTouches[0].clientX && e.changedTouches[0].clientY) {
+      //Special workaround for Chrome desktop in tablet emulation. Need to
+      //confirm if this is sufficient for actual touch devices.
+      clientX = e.changedTouches[0].clientX;
+      clientY = e.changedTouches[0].clientY;
     }
 
     // SVG scaling: usually not an issue.

--- a/src/lib/Utility.js
+++ b/src/lib/Utility.js
@@ -9,8 +9,8 @@ export const Utility = {
     //var eve = e || window.event;
     e.preventDefault && e.preventDefault();
     e.stopPropagation && e.stopPropagation();
-    e.returnValue = false;
-    e.cancelBubble = true;
+    //e.returnValue = false;  //Deprecated, but keep in comments just in case IE11 users complain
+    //e.cancelBubble = true;  //Deprecated
     return false;
   },
 

--- a/src/styles/components/subject-viewer.styl
+++ b/src/styles/components/subject-viewer.styl
@@ -2,6 +2,7 @@
   background-image: url('../images/bg-pattern.png')
   padding-top: 0 !important
   padding-bottom: 0 !important
+  touch-action: none  //Prevents intrepreting touch input as scroll/pan commands. Works in conjunction with onTouchStart={(e)=>{e.preventDefault();e.cancelPropogation()}}
 
   &__error
     align-items: center


### PR DESCRIPTION
## PR Overview
This PR attempts to add touch events to the Subject Viewer, allowing a user with an iPad (for example) to perform the same actions as a user wielding a computer with a mouse.

### Comments
Hey! I turns out I actually added touch sensing in `getPointerXY` in ASM, I just never hooked up the event listeners - so that's one major part of calculations already done. 👍 

```
SubjectViewer.getPointerXY(e) {
  const boundingBox = this.getBoundingBox();
  let clientX = 0;
  let clientY = 0;
  if (e.clientX && e.clientY) {
    clientX = e.clientX;
    clientY = e.clientY;
  } else if (e.touches && e.touches.length > 0 && e.touches[0].clientX &&  //Hahaha noice
      e.touches[0].clientY) {
    clientX = e.touches[0].clientX;
    clientY = e.touches[0].clientY;
  }
  ...
}
```

Adding `<svg onTouchStart={this.onMouseDown} etc etc >` seems to do most of the work, but I have an issue where touch-dragging (i.e. the equivalent of mouse-click-drag) _still causes the default "scroll webpage"_ action to take place. I suspect this has something to do with the Touch Event not being stopped properly, but debugging is still ongoing.

### Status
WIP