### PR TITLE
IE11 Compatibility

### DIFF
--- a/src/index.tpl.html
+++ b/src/index.tpl.html
@@ -15,5 +15,6 @@
   <body>
     <div id="root"></div>
     <%= htmlWebpackPlugin.options.gtm %>
+    <script src="https://ft-polyfill-service.herokuapp.com/v2/polyfill.min.js?features=default,es6,Array.prototype.includes,Array.prototype.keys"></script>
   </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = {
   devtool: 'eval-source-map',
   devServer: {
     contentBase: path.join(__dirname, '/src/'),
+    disableHostCheck: true,  //Enable localhost access on VMs, i.e. for our IE11 testing
     historyApiFallback: true,
     hot: true,
     inline: true,


### PR DESCRIPTION
## PR Overview
Oh IE11, how could we have forgotten about you? (Oh, right: we _tried really hard.)_ This PR adds some quick fixes that allows IE11 users to access Scribes, and, just as importantly, allows local devs to test the website on their VMs because nobody actually installs IE11 on their machines if not held at gunpoint.

- Added polyfill service. Same as ASM, FYI. Added at the end <body> for performance reasons.
- Added a config option in webpack that disables the host-checking security mechanism; without this `disableHostCheck` option, accessing the localhost from a VM would lead to a fatal `Invalid Host header` error when accessing the webpage.

### Status
Simple fix, ready for review.