### PR TITLE
Tweak Keyboard in the Annotation Box

### DIFF
--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -27,6 +27,7 @@ const INPUT_STATE = {
 };
 
 const ANNOTATION_BOX_DIMENSIONS = { height: 600, width: 700 };
+const ANNOTATION_BOX_NO_KEYBOARD_DIMENSIONS = { height: 250, width: 700 };
 
 class SubjectViewer extends React.Component {
   constructor(props) {
@@ -216,7 +217,8 @@ class SubjectViewer extends React.Component {
       this.props.dispatch(addAnnotationPoint(pointerXYOnImage.x, pointerXYOnImage.y, this.props.frame));
       if (this.props.annotationInProgress && this.props.annotationInProgress.points &&
           this.props.annotationInProgress.points.length > 1) {
-        this.props.dispatch(toggleDialog(<SelectedAnnotation />, '', ANNOTATION_BOX_DIMENSIONS));
+        const dimensions = this.props.showKeyboard ? ANNOTATION_BOX_DIMENSIONS : ANNOTATION_BOX_NO_KEYBOARD_DIMENSIONS;
+        this.props.dispatch(toggleDialog(<SelectedAnnotation />, '', dimensions));
         this.props.dispatch(completeAnnotation());
       }
     } else if (this.props.viewerState === SUBJECTVIEWER_STATE.CROPPING) {
@@ -263,7 +265,8 @@ class SubjectViewer extends React.Component {
 
   onSelectAnnotation(indexOfAnnotation) {
     this.props.dispatch(selectAnnotation(indexOfAnnotation));
-    this.props.dispatch(toggleDialog(<SelectedAnnotation />, '', ANNOTATION_BOX_DIMENSIONS));
+    const dimensions = this.props.showKeyboard ? ANNOTATION_BOX_DIMENSIONS : ANNOTATION_BOX_NO_KEYBOARD_DIMENSIONS;
+    this.props.dispatch(toggleDialog(<SelectedAnnotation />, '', dimensions));
   }
 
   render() {
@@ -375,6 +378,7 @@ SubjectViewer.propTypes = {
   translationX: PropTypes.number,
   translationY: PropTypes.number,
   scaling: PropTypes.number,
+  showKeyboard: PropTypes.bool,
   subjectStatus: PropTypes.string,
   viewerSize: PropTypes.shape({
     width: PropTypes.number,
@@ -394,6 +398,7 @@ SubjectViewer.defaultProps = {
   popup: null,
   rotation: 0,
   scaling: 1,
+  showKeyboard: true,
   subjectStatus: '',
   translationX: 0,
   translationY: 0,
@@ -416,6 +421,7 @@ const mapStateToProps = (state) => {
     popup: state.dialog.popup,
     rotation: sv.rotation,
     scaling: sv.scaling,
+    showKeyboard: state.keyboard.showKeyboard,
     subjectStatus: state.subject.status,
     translationX: sv.translationX,
     translationY: sv.translationY,

--- a/src/ducks/keyboard.js
+++ b/src/ducks/keyboard.js
@@ -3,10 +3,12 @@ import { KeyboardOptions } from '../lib/KeyboardTypes';
 const initialState = {
   activeScript: KeyboardOptions[0],
   modern: true,
+  showKeyboard: true,
   index: 0
 };
 
 const SET_KEYBOARD = 'SET_KEYBOARD';
+const TOGGLE_KEYBOARD = 'TOGGLE_KEYBOARD';
 const TOGGLE_MODERN = 'TOGGLE_MODERN';
 
 const keyboardReducer = (state = initialState, action) => {
@@ -15,6 +17,11 @@ const keyboardReducer = (state = initialState, action) => {
       return Object.assign({}, state, {
         activeScript: action.activeScript,
         index: action.index
+      });
+
+    case TOGGLE_KEYBOARD:
+      return Object.assign({}, state, {
+        showKeyboard: action.showKeyboard
       });
 
     case TOGGLE_MODERN:
@@ -39,9 +46,10 @@ const setKeyboard = (index) => {
   };
 };
 
-const toggleModern = () => {
+const toggleModern = (setToFalse = false) => {
   return (dispatch, getState) => {
-    const modern = !getState().keyboard.modern;
+    let modern = !getState().keyboard.modern;
+    if (setToFalse) { modern = false; }
 
     dispatch({
       type: TOGGLE_MODERN,
@@ -50,9 +58,21 @@ const toggleModern = () => {
   };
 };
 
+const toggleKeyboard = () => {
+  return (dispatch, getState) => {
+    const showKeyboard = !getState().keyboard.showKeyboard;
+
+    dispatch({
+      type: TOGGLE_KEYBOARD,
+      showKeyboard
+    });
+  };
+};
+
 export default keyboardReducer;
 
 export {
   setKeyboard,
+  toggleKeyboard,
   toggleModern
 };


### PR DESCRIPTION
This PR addressed comments made in #35. We had originally discussed disabling the script change buttons if the modern characters were shown, but this was adjusted to automatically hide modern characters if the script was changed (which seemed more intuitive).