### PR TITLE
Implement SubjectViewer Translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1818,9 +1818,9 @@
       "integrity": "sha1-CHp7/0L0GmzAsuL7cxKnwpkE+6o="
     },
     "date-names": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/date-names/-/date-names-0.1.11.tgz",
-      "integrity": "sha512-wr7nOFsDX6IkjFVCk1BDMXRzC93E7S2BJgP81K1wJXKUJuKmDcTeCMLhVyFfdwXUBf6IKpPMcQh4ja2RdG3xOQ=="
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/date-names/-/date-names-0.1.12.tgz",
+      "integrity": "sha512-HYc4+Rl53sOHh9R0pgpgqzZy471E4cFXLOjJDQImGOAeacbAV87+RUO70iE1Mfvnp1yuS2V8Y+/n1nS7OoMYiw=="
     },
     "date-now": {
       "version": "0.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1645,9 +1645,9 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "counterpart": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/counterpart/-/counterpart-0.18.5.tgz",
-      "integrity": "sha512-Od4oDJpmtit8sk42OYtRxMBl1FwRsAfTVQFHTHCNCp45ydP2VVoDihLJho25o12rdeSxtK+rZ0qWKxCIqjoNdw=="
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/counterpart/-/counterpart-0.18.6.tgz",
+      "integrity": "sha512-cAIDAYbC3x8S2DDbvFEJ4TzPtPYXma25/kfAkfmprNLlkPWeX4SdUp1c2xklfphqCU3HnDaivR4R3BrAYf5OMA=="
     },
     "create-ecdh": {
       "version": "4.0.0",
@@ -2971,6 +2971,11 @@
       "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
       "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
       "dev": true
+    },
+    "flat": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-2.0.1.tgz",
+      "integrity": "sha1-cOKRiKdL4MPIlAnu0fqVd5B64y8="
     },
     "flat-cache": {
       "version": "1.3.0",
@@ -4904,8 +4909,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -7489,6 +7493,11 @@
       "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.4.0.tgz",
       "integrity": "sha1-ZsFNyd+ac7L7v71gIXJugKYT6xU="
     },
+    "react-localize-redux": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/react-localize-redux/-/react-localize-redux-2.16.0.tgz",
+      "integrity": "sha512-3pIZle364xLKYABFj4xvmqKpj1JZ97rib1CMoRU4wElSDZcRLEPWXr/bn/O1dKkMObYqq/eSe4YkAYh3Q4LEdw=="
+    },
     "react-proxy": {
       "version": "3.0.0-alpha.1",
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz",
@@ -7911,6 +7920,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
+    },
+    "reselect": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
+      "integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc="
     },
     "resolve": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/zooniverse/scribes-of-the-cairo-geniza",
   "dependencies": {
     "classnames": "~2.2.5",
+    "counterpart": "~0.18.6",
     "history": "~4.6.3",
     "markdownz": "~7.3.1",
     "panoptes-client": "~2.8.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/zooniverse/scribes-of-the-cairo-geniza",
   "dependencies": {
     "classnames": "~2.2.5",
-    "counterpart": "^0.18.1",
+    "counterpart": "~0.18.6",
     "history": "~4.6.3",
     "markdownz": "~7.3.1",
     "panoptes-client": "~2.8.0",
@@ -33,6 +33,7 @@
     "publisssh": "^1.1.0",
     "react": "~15.6.1",
     "react-dom": "~15.6.1",
+    "react-localize-redux": "~2.16.0",
     "react-redux": "~5.0.5",
     "react-rnd": "^5.1.0",
     "react-router": "~4.1.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "homepage": "https://github.com/zooniverse/scribes-of-the-cairo-geniza",
   "dependencies": {
     "classnames": "~2.2.5",
-    "counterpart": "~0.18.6",
     "history": "~4.6.3",
     "markdownz": "~7.3.1",
     "panoptes-client": "~2.8.0",

--- a/src/components/CollectionsManager.jsx
+++ b/src/components/CollectionsManager.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Select from 'react-select';
 import { connect } from 'react-redux';
+import { getTranslate, getActiveLanguage } from 'react-localize-redux';
 
 const ENABLE_DRAG = 'handle collections-manager';
 const DISABLE_DRAG = 'collections-manager';
@@ -44,7 +45,7 @@ class CollectionsManager extends React.Component {
     return (
       <div className={ENABLE_DRAG} ref={(c) => { this.manager = c; }}>
         <div className="collections-manager__input-div">
-          <span className="collections-manager__instructions">Add to An Existing Collection</span>
+          <span className="collections-manager__instructions">{this.props.translate('collection.addTo')}</span>
 
           <div
             className="collections-manager__add"
@@ -59,12 +60,12 @@ class CollectionsManager extends React.Component {
                 multi
                 onChange={this.props.onChange}
                 value={this.props.selectedCollections}
-                placeholder="Type to search Collections"
+                placeholder={this.props.translate('collection.search')}
                 loadOptions={this.props.searchCollections}
               />
             </div>
             <button className="button button__dark" disabled={disableAdd} type="button" onClick={this.onAdd}>
-              Add
+              {this.props.translate('collection.add')}
             </button>
           </div>
         </div>
@@ -72,13 +73,13 @@ class CollectionsManager extends React.Component {
         <hr className="white-line" />
 
         <div className="collections-manager__input-div">
-          <span className="collections-manager__instructions">Or create a new Collection</span>
+          <span className="collections-manager__instructions">{this.props.translate('collection.create')}</span>
 
           <form className="collections-manager__create" onSubmit={this.handleSubmission}>
             <input
               ref={(el) => { this.create = el; }}
               onChange={this.handleInputChange}
-              placeholder="Collection Name"
+              placeholder={this.props.translate('collection.name')}
               onMouseDown={() => { this.manager.className = DISABLE_DRAG; }}
               onMouseUp={() => { this.manager.className = ENABLE_DRAG; }}
             />
@@ -100,7 +101,7 @@ class CollectionsManager extends React.Component {
             defaultChecked={false}
           />
           <label htmlFor="private">
-            <span>Private</span>
+            <span>{this.props.translate('collection.private')}</span>
           </label>
         </div>
       </div>
@@ -115,7 +116,8 @@ CollectionsManager.propTypes = {
   onChange: PropTypes.func,
   onSubmit: PropTypes.func,
   searchCollections: PropTypes.func,
-  selectedCollections: PropTypes.arrayOf(PropTypes.object)
+  selectedCollections: PropTypes.arrayOf(PropTypes.object),
+  translate: PropTypes.func
 };
 
 CollectionsManager.defaultProps = {
@@ -124,11 +126,14 @@ CollectionsManager.defaultProps = {
   onChange: () => {},
   onSubmit: () => {},
   searchCollections: () => {},
-  selectedCollections: []
+  selectedCollections: [],
+  translate: () => {}
 };
 
 const mapStateToProps = (state) => ({
-  selectedCollections: state.collections.selectedCollections
+  currentLanguage: getActiveLanguage(state.locale).code,
+  selectedCollections: state.collections.selectedCollections,
+  translate: getTranslate(state.locale)
 });
 
 export default connect(mapStateToProps)(CollectionsManager);

--- a/src/components/CollectionsManager.jsx
+++ b/src/components/CollectionsManager.jsx
@@ -83,7 +83,7 @@ class CollectionsManager extends React.Component {
               onMouseDown={() => { this.manager.className = DISABLE_DRAG; }}
               onMouseUp={() => { this.manager.className = ENABLE_DRAG; }}
             />
-            <button className="button button__dark" disabled={this.state.disableAdd} type="submit">Add</button>
+            <button className="button button__dark" disabled={this.state.disableAdd} type="submit">{this.props.translate('collection.add')}</button>
           </form>
         </div>
 

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -4,6 +4,8 @@ import styled from 'styled-components';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { Tutorial } from 'zooniverse-react-components';
+import { getTranslate, getActiveLanguage } from 'react-localize-redux';
+
 import { fetchGuide } from '../ducks/field-guide';
 import { toggleDialog } from '../ducks/dialog';
 import FieldGuide from '../components/FieldGuide';
@@ -57,7 +59,7 @@ class ControlPanel extends React.Component {
       return this.props.dispatch(toggleDialog(null));
     }
     return this.props.dispatch(toggleDialog(
-      <FieldGuide guide={this.props.guide} icons={this.props.icons} />, 'Field Guide', undefined, 'FieldGuide'));
+      <FieldGuide guide={this.props.guide} icons={this.props.icons} />, this.props.translate('fieldGuide.title'), undefined, 'FieldGuide'));
   }
 
   toggleCribSheet() {
@@ -87,7 +89,7 @@ class ControlPanel extends React.Component {
   }
 
   toggleButton() {
-    const text = this.state.showInfo ? 'Collapse Name & Attribution' : 'Expand Name & Attribution';
+    const text = this.state.showInfo ? this.props.translate('infoBox.collapseName') : this.props.translate('infoBox.expandName');
     return <button className="control-panel__toggle" onClick={this.toggleInfo}>{text}</button>;
   }
 
@@ -116,29 +118,28 @@ class ControlPanel extends React.Component {
     return (
       <div className="control-panel__info">
         <div>
-          <span className="primary-label">Name</span>
+          <span className="primary-label">{this.props.translate('infoBox.name')}</span>
           <span className="body-font">ENA NS 78 0117</span>
         </div>
         <div>
-          <span className="primary-label">Attribution</span>
+          <span className="primary-label">{this.props.translate('infoBox.attribution')}</span>
           <span
             className={classnames('body-font ellipsis', {
               'ellipsis__left': this.props.rtl,
               'ellipsis__right': !this.props.rtl
             })}
-            className="body-font"
           >
             Library of the Jewish Theological Seminary
           </span>
         </div>
-        <a href="/" className="text-link">Library Catalog Page</a>
+        <a href="/" className="text-link">{this.props.translate('infoBox.libraryCatalog')}</a>
       </div>
     );
   }
 
   render() {
-    const fieldGuideText = this.props.dialogComponent === 'FieldGuide' ? 'Hide Field Guide' : 'Show Field Guide';
-    const cribSheetText = this.props.dialogComponent === 'CribSheet' ? 'Hide Crib Sheet' : 'Show Crib Sheet';
+    const fieldGuideText = this.props.dialogComponent === 'FieldGuide' ? this.props.translate('infoBox.hideGuide') : this.props.translate('infoBox.showGuide');
+    const cribSheetText = this.props.dialogComponent === 'CribSheet' ? this.props.translate('infoBox.hideCrib') : this.props.translate('infoBox.showCrib');
     const Section = styled.section`
       left: ${props => props.rtl ? '0' : 'auto'};
       right: ${props => props.rtl ? 'auto' : '0'};
@@ -153,7 +154,7 @@ class ControlPanel extends React.Component {
         rtl={this.props.rtl}
       >
         <div className="control-panel__header">
-          <h4 className="primary-label">Subject info</h4>
+          <h4 className="primary-label">{this.props.translate('infoBox.subjectInfo')}</h4>
           {this.toggleIcon()}
         </div>
         <hr className="plum-line" />
@@ -168,15 +169,15 @@ class ControlPanel extends React.Component {
           <button className="button" onClick={this.toggleFieldGuide}>{fieldGuideText}</button>
 
           {this.props.tutorial && this.props.tutorialStatus === TUTORIAL_STATUS.READY && (
-            <button className="button" onClick={this.showTutorial}>Show Tutorial</button>
+            <button className="button" onClick={this.showTutorial}>{this.props.translate('infoBox.showTutorial')}</button>
           )}
 
           <hr className="white-line" />
 
           <div>
-            <button className="button">Transcribe Page Reverse</button>
-            <button className="button">Save Progress</button>
-            <button className="button button__dark">Done</button>
+            <button className="button">{this.props.translate('infoBox.transcribeReverse')}</button>
+            <button className="button">{this.props.translate('infoBox.saveProgress')}</button>
+            <button className="button button__dark">{this.props.translate('infoBox.finished')}</button>
           </div>
         </div>
       </Section>
@@ -217,6 +218,7 @@ ControlPanel.propTypes = {
   icons: PropTypes.object,
   preferences: PropTypes.object,
   rtl: PropTypes.bool,
+  translate: PropTypes.func,
   tutorial: PropTypes.shape({
     steps: PropTypes.array
   }),
@@ -238,6 +240,7 @@ ControlPanel.defaultProps = {
   icons: null,
   preferences: null,
   rtl: false,
+  translate: () => {},
   tutorial: null,
   tutorialStatus: TUTORIAL_STATUS.IDLE,
   user: null,
@@ -246,12 +249,14 @@ ControlPanel.defaultProps = {
 
 const mapStateToProps = (state) => {
   return {
+    currentLanguage: getActiveLanguage(state.locale).code,
     dialog: state.dialog.data,
     dialogComponent: state.dialog.component,
     guide: state.fieldGuide.guide,
     icons: state.fieldGuide.icons,
     preferences: state.project.userPreferences,
     rtl: state.languages.rtl,
+    translate: getTranslate(state.locale),
     tutorial: state.tutorial.data,
     tutorialStatus: state.tutorial.status,
     user: state.login.user,

--- a/src/components/CribSheet.jsx
+++ b/src/components/CribSheet.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { getTranslate, getActiveLanguage } from 'react-localize-redux';
+
 import { toggleDialog } from '../ducks/dialog';
 import { setViewerState, SUBJECTVIEWER_STATE } from '../ducks/subject-viewer';
 import { activateCard, toggleReferenceMode } from '../ducks/crib-sheet';
@@ -47,9 +49,9 @@ class CribSheet extends React.Component {
     return (
       <div className="crib-sheet__header handle">
         {this.props.user && (
-          <button className={!reference ? 'active-button' : ''} onClick={this.personalMode}>Your Crib Sheet</button>
+          <button className={!reference ? 'active-button' : ''} onClick={this.personalMode}>{this.props.translate('scriptReferences.yourSheet')}</button>
         )}
-        <button className={reference ? 'active-button' : ''} onClick={this.referenceMode}>Script References</button>
+        <button className={reference ? 'active-button' : ''} onClick={this.referenceMode}>{this.props.translate('scriptReferences.title')}</button>
         <button className="close-button" onClick={this.close}>X</button>
         <hr className="plum-line" />
       </div>
@@ -98,8 +100,8 @@ class CribSheet extends React.Component {
   renderInstructions() {
     return (
       <div className="crib-sheet__personal-instructions handle">
-        <span>Use this crib sheet to save snippets for your personal reference.</span>
-        <span>If you&apos;re signed in, the images will be saved throughout your time on this project.</span>
+        <span>{this.props.translate('cribSheet.instructions')}</span>
+        <span>{this.props.translate('cribSheet.instructions2')}</span>
       </div>
     );
   }
@@ -120,12 +122,10 @@ class CribSheet extends React.Component {
           <div className="crib-sheet__personal-card">
             <div>
               <button onClick={this.activateCrop}>
-                <span>
-                  Add Image
-                </span>
+                <span>{this.props.translate('cribSheet.addImage')}</span>
               </button>
             </div>
-            <span className="crib-sheet__add-instructions">Click to add another image</span>
+            <span className="crib-sheet__add-instructions">{this.props.translate('cribSheet.clickAdd')}</span>
           </div>
         </div>
       </div>
@@ -166,6 +166,7 @@ CribSheet.propTypes = {
     update: PropTypes.func
   }),
   referenceMode: PropTypes.bool,
+  translate: PropTypes.func,
   user: PropTypes.shape({
     id: PropTypes.string
   })
@@ -176,14 +177,17 @@ CribSheet.defaultProps = {
   dispatch: () => {},
   preferences: {},
   referenceMode: true,
+  translate: () => {},
   user: null
 };
 
 const mapStateToProps = (state) => {
   return {
     activeCard: state.cribSheet.activeCard,
+    currentLanguage: getActiveLanguage(state.locale).code,
     preferences: state.project.userPreferences,
     referenceMode: state.cribSheet.referenceMode,
+    translate: getTranslate(state.locale),
     user: state.login.user
   };
 };

--- a/src/components/FavoritesButton.jsx
+++ b/src/components/FavoritesButton.jsx
@@ -1,25 +1,34 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { getTranslate, getActiveLanguage } from 'react-localize-redux';
 
-const FavoritesButton = ({ expanded, favorite, toggleFavorite }) => {
+const FavoritesButton = ({ expanded, favorite, translate, toggleFavorite }) => {
   const heart = favorite ? 'fa fa-heart' : 'fa fa-heart-o';
   return (
     <button onClick={toggleFavorite}>
       <i className={heart} />
-      {expanded && (<span>Add to Favorites</span>)}
+      {expanded && (<span>{translate('toolbar.addFavorites')}</span>)}
     </button>
   );
 };
 
 FavoritesButton.defaultProps = {
   expanded: false,
-  favorite: false
+  favorite: false,
+  translate: () => {}
 };
 
 FavoritesButton.propTypes = {
   expanded: PropTypes.bool,
   favorite: PropTypes.bool,
-  toggleFavorite: PropTypes.func.isRequired
+  toggleFavorite: PropTypes.func.isRequired,
+  translate: PropTypes.func
 };
 
-export default FavoritesButton;
+const mapStateToProps = state => ({
+  currentLanguage: getActiveLanguage(state.locale).code,
+  translate: getTranslate(state.locale)
+});
+
+export default connect(mapStateToProps)(FavoritesButton);

--- a/src/components/ProjectHeader.jsx
+++ b/src/components/ProjectHeader.jsx
@@ -3,6 +3,8 @@ import { NavLink } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
+import { getTranslate, getActiveLanguage } from 'react-localize-redux';
+
 import { setLanguage, LANGUAGES } from '../ducks/languages';
 
 class ProjectHeader extends React.Component {
@@ -30,39 +32,54 @@ class ProjectHeader extends React.Component {
                 exact
                 to="/"
               >
-                Scribes of the Cairo Geniza
+                {this.props.translate('topNav.site')}
               </NavLink>
               <NavLink
                 activeClassName="project-header__active"
                 className="project-header__link"
                 to="/about"
               >
-                About
+                {this.props.translate('topNav.about')}
               </NavLink>
               <NavLink
                 activeClassName="project-header__active"
                 className="project-header__link"
                 to="/classify"
               >
-                Transcribe
+                {this.props.translate('topNav.transcribe')}
               </NavLink>
               <a
                 className="project-header__link"
                 href="/"
               >
-                Talk
+                {this.props.translate('topNav.talk')}
               </a>
               <a
                 className="project-header__link"
                 href="/"
               >
-                Collect
+                {this.props.translate('topNav.collect')}
               </a>
             </div>
             <div>
-              <button onClick={this.changeLanguage.bind(this, LANGUAGES.ARABIC)}>ع</button>
-              <button onClick={this.changeLanguage.bind(this, LANGUAGES.ENGLISH)}>E</button>
-              <button onClick={this.changeLanguage.bind(this, LANGUAGES.HEBREW)}>ע</button>
+              <button
+                className={classnames({ 'active-language': this.props.language === LANGUAGES.ARABIC })}
+                onClick={this.changeLanguage.bind(this, LANGUAGES.ARABIC)}
+              >
+                ع
+              </button>
+              <button
+                className={classnames({ 'active-language': this.props.language === LANGUAGES.ENGLISH })}
+                onClick={this.changeLanguage.bind(this, LANGUAGES.ENGLISH)}
+              >
+                E
+              </button>
+              <button
+                className={classnames({ 'active-language': this.props.language === LANGUAGES.HEBREW })}
+                onClick={this.changeLanguage.bind(this, LANGUAGES.HEBREW)}
+              >
+                ע
+              </button>
             </div>
           </nav>
         </div>
@@ -73,20 +90,27 @@ class ProjectHeader extends React.Component {
 
 ProjectHeader.propTypes = {
   dispatch: PropTypes.func,
+  language: PropTypes.string,
   location: PropTypes.shape({
     pathname: PropTypes.string
   }),
-  rtl: PropTypes.bool
+  rtl: PropTypes.bool,
+  translate: PropTypes.func
 };
 
 ProjectHeader.defaultProps = {
   dispatch: () => {},
+  language: LANGUAGES.ENGLISH,
   location: {},
-  rtl: false
+  rtl: false,
+  translate: () => {}
 };
 
 const mapStateToProps = state => ({
-  rtl: state.languages.rtl
+  currentLanguage: getActiveLanguage(state.locale).code,
+  language: state.languages.language,
+  rtl: state.languages.rtl,
+  translate: getTranslate(state.locale)
 });
 
 export default connect(mapStateToProps)(ProjectHeader);

--- a/src/components/ScriptReferences.jsx
+++ b/src/components/ScriptReferences.jsx
@@ -68,7 +68,7 @@ class ScriptReferences extends React.Component {
                 key={`SCRIPT_FILTER_${i}`}
                 onClick={this.toggleFilter.bind(this, key)}
               >
-                {KEYBOARD_TYPES[key]}
+                {this.props.translate(`scriptReferences.${KEYBOARD_TYPES[key].toLowerCase()}`)}
               </button>
             );
           })}
@@ -135,10 +135,11 @@ class ScriptReferences extends React.Component {
 
     return (
       <div className="script-references__groups" key={`${type}_KEYBOARDS`}>
-        <span>{type}</span>
+        <span>{this.props.translate(`scriptReferences.${type.toLowerCase()}`)}</span>
         <span>One sentence about where {type} is found.</span>
         <div className="script-references__scripts">
           {collection.map((script, i) => {
+            const scriptTitle = script.name.toLowerCase().replace(/\s+/g, '');
             const styles = {};
             styles.backgroundImage = `url('${script.img}')`;
             return (
@@ -147,7 +148,7 @@ class ScriptReferences extends React.Component {
                   <div className="alef" style={styles} />
                   <div className={`script-references__script ${script.class}`} />
                 </button>
-                <span>{script.name}</span>
+                <span>{this.props.translate(`scriptReferences.types.${scriptTitle}`)}</span>
               </div>
             );
           })}

--- a/src/components/ScriptReferences.jsx
+++ b/src/components/ScriptReferences.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
+import { getTranslate, getActiveLanguage } from 'react-localize-redux';
+
 import { KeyboardOptions, KEYBOARD_TYPES } from '../lib/KeyboardTypes';
 import { setKeyboard, toggleKeyboard, toggleModern } from '../ducks/keyboard';
 import {
@@ -54,7 +56,7 @@ class ScriptReferences extends React.Component {
     const allActive = this.props.activeFilters.length === 3;
     return (
       <div className="script-references__filter">
-        <span className="secondary-label">Filter Scripts By</span>
+        <span className="secondary-label">{this.props.translate('scriptReferences.filterBy')}</span>
         <div>
           {Object.keys(KEYBOARD_TYPES).map((key, i) => {
             const isActive = this.props.activeFilters.indexOf(KEYBOARD_TYPES[key]) >= 0;
@@ -100,7 +102,7 @@ class ScriptReferences extends React.Component {
   }
 
   renderLetters() {
-    const text = !this.state.keyboardSent ? 'Send Script to Keyboard \u2192' : 'Sent'
+    const text = !this.state.keyboardSent ? `${this.props.translate('scriptReferences.sendScript')} \u2192` : 'Sent'
 
     return (
       <div className="script-references__letters">
@@ -169,11 +171,10 @@ class ScriptReferences extends React.Component {
   }
 
   render() {
-    const toggleText = this.props.scriptSelection ? 'Back' : 'Change';
+    const toggleText = this.props.scriptSelection ? this.props.translate('scriptReferences.back') : this.props.translate('scriptReferences.changeScript');
     const rightPanel = !this.props.scriptSelection ? (
       <span className="body-font">
-        Change the script type to see variations in character
-        formation based on location and time period.
+        {this.props.translate('scriptReferences.changeInstructions')}
       </span>) : this.renderFilters();
     const bodyRender = this.props.scriptSelection ? this.renderScripts() : this.renderLetters();
 
@@ -181,7 +182,7 @@ class ScriptReferences extends React.Component {
       <div className="script-references handle">
         <div className="script-references__header">
           <div>
-            <span className="secondary-label">Current Script Type</span>
+            <span className="secondary-label">{this.props.translate('scriptReferences.currentScript')}</span>
             <div>
               <span className="h1-font">{this.props.activeScript.name} {this.props.activeScript.type}</span>
               <button className="text-link" onClick={this.toggleSelection}>{toggleText}</button>
@@ -206,20 +207,24 @@ ScriptReferences.propTypes = {
     type: PropTypes.string
   }),
   dispatch: PropTypes.func,
-  scriptSelection: PropTypes.bool
+  scriptSelection: PropTypes.bool,
+  translate: PropTypes.func
 };
 
 ScriptReferences.defaultProps = {
   activeFilters: [],
   activeScript: KeyboardOptions[0],
   dispatch: () => {},
-  scriptSelection: false
+  scriptSelection: false,
+  translate: () => {}
 };
 
 const mapStateToProps = state => ({
   activeScript: state.cribSheet.activeScript,
   activeFilters: state.cribSheet.activeFilters,
-  scriptSelection: state.cribSheet.scriptSelection
+  currentLanguage: getActiveLanguage(state.locale).code,
+  scriptSelection: state.cribSheet.scriptSelection,
+  translate: getTranslate(state.locale)
 });
 
 export default connect(mapStateToProps)(ScriptReferences);

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -286,7 +286,7 @@ class SelectedAnnotation extends React.Component {
         {this.props.showKeyboard && (
           <div className="selected-annotation__keyboard-div">
             <hr />
-            <span className="secondary-label">Current Script Type</span>
+            <span className="secondary-label">{this.props.translate('scriptReferences.currentScript')}</span>
             <div>
               <div className="selected-annotation__script-select">
                 <button onClick={this.previousScript}>&#9664;</button>

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { getTranslate, getActiveLanguage } from 'react-localize-redux';
+
 import { toggleDialog, togglePopup } from '../ducks/dialog';
 import { pressedKey, setKeyboard, toggleKeyboard, toggleModern } from '../ducks/keyboard';
 import {
@@ -203,7 +205,7 @@ class SelectedAnnotation extends React.Component {
     const notes = emptyText ? 'You cannot save an empty transcription.' : '';
     this.props.dispatch(togglePopup(
       <QuestionPrompt
-        confirm="Yes, delete"
+        confirm={this.props.translate('cribSheet.confirm')}
         deny="No, continue transcribing"
         notes={notes}
         onConfirm={this.deleteAnnotation}
@@ -233,7 +235,7 @@ class SelectedAnnotation extends React.Component {
   }
 
   render() {
-    const keyboardToggleText = this.props.showKeyboard ? 'Close Keyboard' : 'Show Keyboard';
+    const keyboardToggleText = this.props.showKeyboard ? this.props.translate('transcribeBox.closeKeyboard') : this.props.translate('transcribeBox.openKeyboard');
     let currentScript = 'Current Script';
     if (this.props.activeScript && this.props.activeScript.name && this.props.activeScript.type) {
       currentScript = `${this.props.activeScript.name} ${this.props.activeScript.type}`;
@@ -242,14 +244,14 @@ class SelectedAnnotation extends React.Component {
       <div className={ENABLE_DRAG} ref={(c) => { this.annotationBox = c; }}>
         <div className="selected-annotation__header">
           <div>
-            <h2 className="primary-label">Transcribe</h2>
+            <h2 className="primary-label">{this.props.translate('transcribeBox.title')}</h2>
             <hr className="plum-line" />
           </div>
           <button className="close-button" onClick={this.closePrompt}>X</button>
         </div>
         <div className="selected-annotation__instructions">
-          <span>The Hebrew language reads from right to left, so start on the right side. </span>
-          <span>Check out examples of different alphabets in the Crib Sheet.</span>
+          <span>{this.props.translate('transcribeBox.instructions')}</span>
+          <span>{this.props.translate('transcribeBox.instructions2')}</span>
         </div>
         <input
           type="text"
@@ -259,6 +261,7 @@ class SelectedAnnotation extends React.Component {
           onKeyUp={this.onKeyUp}
           onMouseDown={() => { this.annotationBox.className = DISABLE_DRAG; }}
           onMouseUp={() => { this.annotationBox.className = ENABLE_DRAG; }}
+          placeholder={this.props.translate('transcribeBox.textArea')}
         />
         <div className="selected-annotation__controls">
           <div>
@@ -276,8 +279,8 @@ class SelectedAnnotation extends React.Component {
             <button className="text-link" onClick={this.toggleKeyboardView}>{keyboardToggleText}</button>
           </div>
           <div>
-            <button className="button" onClick={this.deletePrompt}>Delete</button>
-            <button className="button button__dark" onClick={this.saveText}>Done</button>
+            <button className="button" onClick={this.deletePrompt}>{this.props.translate('cribSheet.delete')}</button>
+            <button className="button button__dark" onClick={this.saveText}>{this.props.translate('transcribeBox.done')}</button>
           </div>
         </div>
         {this.props.showKeyboard && (
@@ -330,6 +333,7 @@ SelectedAnnotation.propTypes = {
   }),
   showKeyboard: PropTypes.bool,
   showModernKeyboard: PropTypes.bool,
+  translate: PropTypes.func,
   updateSize: PropTypes.func
 };
 
@@ -340,15 +344,18 @@ SelectedAnnotation.defaultProps = {
   selectedAnnotation: null,
   showKeyboard: true,
   showModernKeyboard: true,
+  translate: () => {},
   updateSize: () => {}
 };
 
 const mapStateToProps = state => ({
   activeScript: state.keyboard.activeScript,
+  currentLanguage: getActiveLanguage(state.locale).code,
   keyboardIndex: state.keyboard.index,
   showKeyboard: state.keyboard.showKeyboard,
   showModernKeyboard: state.keyboard.modern,
-  selectedAnnotation: state.annotations.selectedAnnotation
+  selectedAnnotation: state.annotations.selectedAnnotation,
+  translate: getTranslate(state.locale)
 });
 
 export default connect(mapStateToProps)(SelectedAnnotation);

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -206,7 +206,7 @@ class SelectedAnnotation extends React.Component {
     this.props.dispatch(togglePopup(
       <QuestionPrompt
         confirm={this.props.translate('cribSheet.confirm')}
-        deny="No, continue transcribing"
+        deny={this.props.translate('cribSheet.deny')}
         notes={notes}
         onConfirm={this.deleteAnnotation}
         onDeny={this.closePopup}

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
+import { getTranslate, getActiveLanguage } from 'react-localize-redux';
 
 import CollectionsContainer from '../containers/CollectionsContainer';
 import { toggleDialog } from '../ducks/dialog';
@@ -14,6 +15,8 @@ import { setScaling, resetView,
   // setTranslation, updateViewerSize, updateImageSize,
   SUBJECTVIEWER_STATE
 } from '../ducks/subject-viewer';
+
+
 
 const ROTATION_STEP = 90;
 const ZOOM_STEP = 0.1;
@@ -80,7 +83,7 @@ class Toolbar extends React.Component {
     return (
       <button className="button-header" onClick={this.togglePanel}>
         {this.state.showPanel && (
-          <span>Toolbar</span>
+          <span>{this.props.translate('toolbar.title')}</span>
         )}
         <i
           className={classnames('button-header', {
@@ -117,41 +120,41 @@ class Toolbar extends React.Component {
           onClick={this.useAnnotationTool}
         >
           <i>&#x02A01;</i>
-          {expanded && (<span>Add Transcription</span>)}
+          {expanded && (<span>{this.props.translate('toolbar.addTranscription')}</span>)}
         </button>
         <button
           className={(this.props.viewerState === SUBJECTVIEWER_STATE.NAVIGATING) ? 'active' : ''}
           onClick={this.useNavigationTool}
         >
           <i className="fa fa-arrows" />
-          {expanded && (<span>Pan</span>)}
+          {expanded && (<span>{this.props.translate('toolbar.pan')}</span>)}
         </button>
 
         <hr />
 
         <button onClick={this.useZoomIn}>
           <i className="fa fa-plus" />
-          {expanded && (<span>Zoom In</span>)}
+          {expanded && (<span>{this.props.translate('toolbar.zoomIn')}</span>)}
         </button>
         <button onClick={this.useZoomOut}>
           <i className="fa fa-minus" />
-          {expanded && (<span>Zoom Out</span>)}
+          {expanded && (<span>{this.props.translate('toolbar.zoomOut')}</span>)}
         </button>
         <button onClick={this.rotateSubject}>
           <i className="fa fa-repeat" />
-          {expanded && (<span>Rotate</span>)}
+          {expanded && (<span>{this.props.translate('toolbar.rotate')}</span>)}
         </button>
         <button onClick={this.invertColors}>
           <i className="fa fa-adjust" />
-          {expanded && (<span>Invert Colors</span>)}
+          {expanded && (<span>{this.props.translate('toolbar.invertColors')}</span>)}
         </button>
         <button>
           <i className="fa fa-eye" />
-          {expanded && (<span>Toggle Previous Marks</span>)}
+          {expanded && (<span>{this.props.translate('toolbar.showHints')}</span>)}
         </button>
         <button onClick={this.resetView}>
           <i className="fa fa-refresh" />
-          {expanded && (<span>Reset Image</span>)}
+          {expanded && (<span>{this.props.translate('toolbar.resetImage')}</span>)}
         </button>
 
         <hr />
@@ -167,7 +170,7 @@ class Toolbar extends React.Component {
         {this.props.user && (
           <button onClick={this.showCollections}>
             <i className="fa fa-list" />
-            {expanded && (<span>Add To Collection</span>)}
+            {expanded && (<span>{this.props.translate('toolbar.addCollection')}</span>)}
           </button>
         )}
 
@@ -183,6 +186,7 @@ Toolbar.propTypes = {
   rotation: PropTypes.number,
   rtl: PropTypes.bool,
   scaling: PropTypes.number,
+  translate: PropTypes.func,
   user: PropTypes.shape({
     id: PropTypes.string
   }),
@@ -195,6 +199,7 @@ Toolbar.defaultProps = {
   rotation: 0,
   rtl: false,
   scaling: 0,
+  translate: () => {},
   user: null,
   viewerState: SUBJECTVIEWER_STATE.NAVIGATING
 };
@@ -202,10 +207,12 @@ Toolbar.defaultProps = {
 const mapStateToProps = (state) => {
   const sv = state.subjectViewer;
   return {
+    currentLanguage: getActiveLanguage(state.locale).code,
     favoriteSubject: state.subject.favorite,
     rotation: sv.rotation,
     rtl: state.languages.rtl,
     scaling: sv.scaling,
+    translate: getTranslate(state.locale),
     user: state.login.user,
     viewerState: sv.viewerState
   };

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -98,7 +98,7 @@ class Toolbar extends React.Component {
   showCollections() {
     const PANE_SIZE = { height: 300, width: 500 };
     this.props.dispatch(
-      toggleDialog(<CollectionsContainer closePopup={this.closeDialog} />, 'Add to Collections', PANE_SIZE));
+      toggleDialog(<CollectionsContainer closePopup={this.closeDialog} />, this.props.translate('collection.title'), PANE_SIZE));
   }
 
   closeDialog() {

--- a/src/ducks/initialize.js
+++ b/src/ducks/initialize.js
@@ -1,6 +1,7 @@
 import { fetchProject } from './project';
 import { fetchWorkflow } from './workflow';
 import { fetchGuide } from './field-guide';
+import { initializeLanguages } from './languages';
 
 const FETCH_RESOURCES = 'FETCH_RESOURCES';
 const FETCH_RESOURCES_SUCCESS = 'FETCH_RESOURCES_SUCCESS';
@@ -40,6 +41,7 @@ const initializeReducer = (state = initialState, action) => {
 const fetchResources = () => {
   return (dispatch) => {
     dispatch({ type: FETCH_RESOURCES });
+    dispatch(initializeLanguages());
 
     Promise.all([
       dispatch(fetchProject()),

--- a/src/ducks/languages.js
+++ b/src/ducks/languages.js
@@ -1,3 +1,11 @@
+import {
+  addTranslationForLanguage, initialize, setActiveLanguage
+} from 'react-localize-redux';
+
+import english from '../locales/en';
+import arabic from '../locales/ar';
+import hebrew from '../locales/he';
+
 const LANGUAGES = {
   ENGLISH: 'English',
   HEBREW: 'Hebrew',
@@ -31,7 +39,6 @@ const setLanguage = (language) => {
     if (language === LANGUAGES.HEBREW || language === LANGUAGES.ARABIC) {
       rtl = true;
     }
-
     let newLang = 'en';
     if (language === LANGUAGES.HEBREW) {
       newLang = 'he';
@@ -41,6 +48,7 @@ const setLanguage = (language) => {
     if (document.documentElement.lang) {
       document.documentElement.lang = newLang;
     }
+    dispatch(setActiveLanguage(newLang));
 
     dispatch({
       type: SET_LANGUAGE,
@@ -50,9 +58,20 @@ const setLanguage = (language) => {
   };
 };
 
+const initializeLanguages = () => {
+  return (dispatch) => {
+    const languages = ['en', 'ar', 'he'];
+    dispatch(initialize(languages));
+    dispatch(addTranslationForLanguage(english, 'en'));
+    dispatch(addTranslationForLanguage(hebrew, 'he'));
+    dispatch(addTranslationForLanguage(arabic, 'ar'));
+  };
+};
+
 export default languagesReducer;
 
 export {
+  initializeLanguages,
   setLanguage,
   LANGUAGES
 };

--- a/src/ducks/reducer.js
+++ b/src/ducks/reducer.js
@@ -1,4 +1,5 @@
 import { combineReducers } from 'redux';
+import { localeReducer as locale } from 'react-localize-redux';
 import dialog from './dialog';
 import fieldGuide from './field-guide';
 import initialize from './initialize';
@@ -23,6 +24,7 @@ export default combineReducers({
   dialog,
   fieldGuide,
   initialize,
+  locale,
   keyboard,
   languages,
   login,

--- a/src/locales/ar.js
+++ b/src/locales/ar.js
@@ -63,8 +63,8 @@ export default {
     scriptTypes: 'أنواع الخط العبري',
     yourSheet: 'الورقة المرجعية الخاصة بكم',
     types: {
-      orientalNE: 'عراقي وإيراني',
-      orientalSW: 'مصري وفلسطيني',
+      orientalne: 'عراقي وإيراني',
+      orientalsw: 'مصري وفلسطيني',
       maghrebi: 'مغربي',
       sephardi: 'سفاردي',
       yemenite: 'يمني',

--- a/src/locales/ar.js
+++ b/src/locales/ar.js
@@ -103,7 +103,8 @@ export default {
     deletePrompt: '?هل تريد حذف هذا المقتطف',
     deletePrompt2: '.لا يمكن التراجع عن هذا الإجراء',
     cancel: 'لا، إلغاء ذلك',
-    confirm: 'نعم، حذف'
+    confirm: 'نعم، حذف',
+    deny: 'No, continue transcribing'
   },
   helpers: {
     getStarted: 'تبدأ بالنقر على "إضافة النسخ"',

--- a/src/locales/ar.js
+++ b/src/locales/ar.js
@@ -1,0 +1,132 @@
+export default {
+  toolbar: {
+    title: 'شريط الأدوات',
+    addTranscription: 'بدء النسخ',
+    pan: 'نقل القطعة',
+    zoomIn: 'تكبير حجم الصورة',
+    zoomOut: 'تصغير حجم الصورة',
+    rotate: 'تدوير الصورة',
+    invertColors: 'عكس الألوان',
+    showHints: 'Show Keyword Hints',
+    hideHints: 'Hide Keyword Hints',
+    resetImage: 'إعادة تعيين الصورة',
+    addFavorites: 'إضافة إلى المفضلة',
+    addCollection: 'إضافة إلى مجموعة'
+  },
+  infoBox: {
+    subjectInfo: 'معلومات الموضوع',
+    name: 'اسم',
+    attribution: 'مصدر',
+    libraryCatalog: 'صفحة فهرس المكتبة',
+    collapseName: 'إخفاء اسم و مصدر',
+    expandName: 'إظهار اسم ومصدر',
+    showCrib: 'إظهار ورقة مرجعية',
+    hideCrib: 'إخفاء ورقة مرجعية',
+    transcribeReverse: 'نسخ عكس الصفحة',
+    transcribeFront: 'نسخ جبهة الصفحة',
+    showGuide: 'إظهار معلومات إضافية',
+    hideGuide: 'إخفاء معلومات إضافية',
+    showTutorial: 'إظهار الدرس التعليمي ',
+    hideTutorial: 'إخفاء الدرس التعليمي',
+    saveProgress: 'حفظ التقدم',
+    finished: 'تم الانتهاء'
+  },
+  transcribeBox: {
+    title: 'نسخ',
+    instructions: '.تتم قراءة اللغة العبرية من اليمين إلى اليسار، فبدأ على اليمين',
+    instructions2: '.ستحقق أمثلة مختلفة من الأبجديات في الورقة المرجعية',
+    textArea: 'محتوى مربع الكتابة',
+    openKeyboard: 'إظهار لوحة المفاتيح',
+    closeKeyboard: 'إخفاء لوحة المفاتيح',
+    cancel: 'إلغاء',
+    done: 'منجز'
+  },
+  collection: {
+    title: 'إضافة إلى مجموعة',
+    addTo: 'إضافة إلى مجموعة موجودة',
+    search: 'أكتب لبحث المجموعات',
+    add: 'إضافة',
+    create: 'أو إنشاء مجموعة جديدة',
+    name: 'اسم المجموعة',
+    private: 'خاص'
+  },
+  topNav: {
+    title: 'فوق - الملاحة',
+    site: 'كتبة الجنيزا بالقاهرة',
+    about: 'نبذة',
+    transcribe: 'نسخ',
+    talk: 'لوحة الرسائل',
+    collect: 'تجميع'
+  },
+  scriptReferences: {
+    title: 'ورقة مرجعية لخطوط',
+    scriptTypes: 'أنواع الخط العبري',
+    yourSheet: 'الورقة المرجعية الخاصة بكم',
+    types: {
+      orientalNE: 'عراقي وإيراني',
+      orientalSW: 'مصري وفلسطيني',
+      maghrebi: 'مغربي',
+      sephardi: 'سفاردي',
+      yemenite: 'يمني',
+      byzantine: 'بيزنطي',
+      ashkenazi: 'أشكنازي',
+      italian: 'إيطالي',
+      square: 'مربع',
+      miniscule: 'ضئيل',
+      cursive: 'بالحروف المتصلة'
+    },
+    sendScript: 'إرسال الحروف إلى لوحة المفاتيح',
+    currentScript: 'نوع الخط الحالي',
+    back: 'الرجوع إلى لوحة المفاتيح',
+    changeScript: 'تبديل الخط',
+    changeInstructions: `
+      تغيير نوع الخط لرؤية اختلافات في تشكيل حرف بناء على الموقع والفترة الزمنية
+    `,
+    filterBy: 'Filter Scripts By',
+    cursive: 'بالحروف المتصلة',
+    miniscule: 'ضئيل',
+    square: 'مربع'
+  },
+  cribSheet: {
+    title: 'ورقة مرجعية',
+    instructions: `
+      Use this crib sheet to save snippets for your personal reference.
+      If you're signed in, the images will be saved throughout your time on
+      this project.
+    `,
+    instructions2: ' ',
+    addImage: 'إضافة صورة',
+    clickAdd: 'انقر هنا لإضافة صورة أخرى',
+    delete: 'حذف',
+    edit: 'تصحيح',
+    save: 'حذف',
+    deletePrompt: '?هل تريد حذف هذا المقتطف',
+    deletePrompt2: '.لا يمكن التراجع عن هذا الإجراء',
+    cancel: 'لا، إلغاء ذلك',
+    confirm: 'نعم، حذف'
+  },
+  helpers: {
+    getStarted: 'تبدأ بالنقر على "إضافة النسخ"',
+    click: 'انقر في بداية ونهاية سطر من النص لإضافة النسخ',
+    draw: 'ارسم مربع حول جزء الصورة التي تريد حفظها'
+  },
+  fieldGuide: {
+    title: 'المعلومات الإضافية'
+  },
+  finished: {
+    title: 'تم الإنتهاء',
+    allTranscribed: 'هل تم نسخ كل شيء؟',
+    instructions: `
+      هل تم نسخ كل سطر في هذه الوثيقة؟ لا تقلق إذا بقيت بعض السطور، نحن نشكرك لمساهمتك
+    `,
+    whenReady: `
+      عندما تكون مستعداً، انقر على "تمام وتكلم" لمناقشة هذه الوثيقة مع فريق البحث للجنيزا بالقاهرة وزملائك المتطوعين، أو انقر على
+      ."تمام" لإنتقال إلى الوثيقة التالية
+    `,
+    allComplete: 'نعم، جميع السطور كاملة',
+    notFinished: 'لا، لم يتم نسخ بعض السطور',
+    cancel: 'إلغاء',
+    done: 'منجز',
+    doneAndTalk: 'منجز و انتقل إلى لوحة الرسائل'
+  }
+};

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -63,8 +63,8 @@ export default {
     scriptTypes: 'Hebrew Script Types',
     yourSheet: 'Your Crib Sheet',
     types: {
-      orientalNE: 'Oriental NE',
-      orientalSW: 'Oriental SW',
+      orientalne: 'Oriental NE',
+      orientalsw: 'Oriental SW',
       maghrebi: 'Maghrebi',
       sephardi: 'Sephardi',
       yemenite: 'Yemenite',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -103,7 +103,8 @@ export default {
     deletePrompt: 'Delete this snippet?',
     deletePrompt2: 'This action cannot be undone.',
     cancel: 'No, cancel',
-    confirm: 'Yes, delete'
+    confirm: 'Yes, delete',
+    deny: 'No, continue transcribing'
   },
   helpers: {
     getStarted: 'Get started by clicking "Add Transcription"',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1,0 +1,134 @@
+export default {
+  toolbar: {
+    title: 'Toolbar',
+    addTranscription: 'Add Transcription',
+    pan: 'Pan',
+    zoomIn: 'Zoom In',
+    zoomOut: 'Zoom Out',
+    rotate: 'Rotate',
+    invertColors: 'Invert Colors',
+    showHints: 'Show Keyword Hints',
+    hideHints: 'Hide Keyword Hints',
+    resetImage: 'Reset Image',
+    addFavorites: 'Add to Favorites',
+    addCollection: 'Add to Collection'
+  },
+  infoBox: {
+    subjectInfo: 'Subject Info',
+    name: 'Name',
+    attribution: 'Attribution',
+    libraryCatalog: 'Library Catalog Page',
+    collapseName: 'Collapse Name & Attribution',
+    expandName: 'Expand Name & Attribution',
+    showCrib: 'Show Crib Sheet',
+    hideCrib: 'Hide Crib Sheet',
+    transcribeReverse: 'Transcribe Page Reverse',
+    transcribeFront: 'Transcribe Page Front',
+    showGuide: 'Show Field Guide',
+    hideGuide: 'Hide Field Guide',
+    showTutorial: 'Show Tutorial',
+    hideTutorial: 'Hide Tutorial',
+    saveProgress: 'Save Progress',
+    finished: 'Finished'
+  },
+  transcribeBox: {
+    title: 'Transcribe',
+    instructions: 'The Hebrew language reads from right to left, so start on the right side.',
+    instructions2: 'Check out examples of different alphabets in the Crib Sheet',
+    textArea: 'Text Area Content',
+    openKeyboard: 'Open Keyboard',
+    closeKeyboard: 'Close Keyboard',
+    cancel: 'Cancel',
+    done: 'Done'
+  },
+  collection: {
+    title: 'Add to Collection',
+    addTo: 'Add to an existing collection',
+    search: 'Type to search Collections',
+    add: 'Add',
+    create: 'Or create a new collection',
+    name: 'Collection Name',
+    private: 'Private'
+  },
+  topNav: {
+    title: 'Top Nav',
+    site: 'Scribes of the Cairo Geniza',
+    about: 'About',
+    transcribe: 'Transcribe',
+    talk: 'Talk',
+    collect: 'Collect'
+  },
+  scriptReferences: {
+    title: 'Script References',
+    scriptTypes: 'Hebrew Script Types',
+    yourSheet: 'Your Crib Sheet',
+    types: {
+      orientalNE: 'Oriental NE',
+      orientalSW: 'Oriental SW',
+      maghrebi: 'Maghrebi',
+      sephardi: 'Sephardi',
+      yemenite: 'Yemenite',
+      byzantine: 'Byzantine',
+      ashkenazi: 'Ashkenazi',
+      italian: 'Italian',
+      square: 'Square',
+      miniscule: 'Miniscule',
+      cursive: 'Cursive'
+    },
+    sendScript: 'Send Script to Keyboard',
+    currentScript: 'Current Script Type',
+    back: 'Back',
+    changeScript: 'Change Script',
+    changeInstructions: `
+      Change the script type tp see variations in character formation based on
+      location and time period.
+    `,
+    filterBy: 'Filter Scripts By',
+    cursive: 'Cursive',
+    miniscule: 'Miniscule',
+    square: 'Square'
+  },
+  cribSheet: {
+    title: 'Crib Sheet',
+    instructions: 'Use this crib sheet to save snippets for your personal reference.',
+    instructions2: `
+      If you're signed in, the images will be saved throughout your time on
+      this project.
+    `,
+    addImage: 'Add Image',
+    clickAdd: 'Click to add another image',
+    delete: 'Delete',
+    edit: 'Edit',
+    save: 'Save',
+    deletePrompt: 'Delete this snippet?',
+    deletePrompt2: 'This action cannot be undone.',
+    cancel: 'No, cancel',
+    confirm: 'Yes, delete'
+  },
+  helpers: {
+    getStarted: 'Get started by clicking "Add Transcription"',
+    click: 'Click at the start and end of a line of text to add a transcription',
+    draw: 'Draw a box around the part of the iamge you\'d like to save'
+  },
+  fieldGuide: {
+    title: 'Field Guide'
+  },
+  finished: {
+    title: 'Finished',
+    allTranscribed: 'Has everything been transcribed?',
+    instructions: `
+      Has every line in this document been transcribed? Don't worry if some lines
+      remain; your contributions are appreciated!
+    `,
+    whenReady: `
+      When you're ready, click Done & Talk to discuss this document with the
+      Cairo Geniza research team and your fellow volunteers, or Done to go to
+      the next document.
+    `,
+    allComplete: 'Yes, all lines are complete',
+    notFinished: 'No, some lines have not been transcribed',
+    cancel: 'Cancel',
+    done: 'Done',
+    doneAndTalk: 'Done & Talk'
+  }
+};

--- a/src/locales/he.js
+++ b/src/locales/he.js
@@ -1,0 +1,128 @@
+export default {
+  toolbar: {
+    title: 'הכלים',
+    addTranscription: 'הוסף תעתוק',
+    pan: 'גלול תמונה',
+    zoomIn: 'הגדל',
+    zoomOut: 'הקטן',
+    rotate: 'סובב',
+    invertColors: 'נגטיב',
+    showHints: 'הצג מילות מפתח',
+    hideHints: 'הסתר מילות מפתח',
+    resetImage: 'אפס תמונה',
+    addFavorites: 'הוסף למועדפים',
+    addCollection: 'הוסף לאוסף'
+  },
+  infoBox: {
+    subjectInfo: 'תיאור הפריט ',
+    name: 'קטע הגניזה',
+    attribution: 'ספריית מקור',
+    libraryCatalog: 'הפריט בקטלוג הספריה',
+    collapseName: 'הצג פרטי קטע הגניזה',
+    expandName: 'סגור פרטי קטע הגניזה',
+    showCrib: 'הצג סוגי כתב',
+    hideCrib: 'סגור סוגי כתב',
+    transcribeReverse: 'עבור לעמוד השני של הדף',
+    transcribeFront: 'חזור לעמוד הראשון',
+    showGuide: 'למידע נוסף',
+    hideGuide: 'סגור מידע נוסף',
+    showTutorial: 'הצג מדריך לעבודה באתר',
+    hideTutorial: 'סגור הדרכה',
+    saveProgress: 'שמור התקדמות',
+    finished: 'סיום'
+  },
+  transcribeBox: {
+    title: 'תעתוק',
+    instructions: '.הקלד את הטקסט שלפניך',
+    instructions2: '.ניתן להיעזר בדוגמאות סוגי כתב לשם זיהוי האותיות',
+    textArea: 'הקלד טקסט כאן',
+    openKeyboard: 'פתח מקלדת',
+    closeKeyboard: 'סגור מקלדת',
+    cancel: 'ביטול',
+    done: 'סיום'
+  },
+  collection: {
+    title: 'הוסף לאוסף',
+    addTo: 'הוסף לאוסף קיים',
+    search: 'הקלד לחיפוש ברשימת האוספים',
+    add: 'הוסף לאוסף',
+    create: 'או צור אוסף חדש',
+    name: 'שם האוסף',
+    private: 'פרטי'
+  },
+  topNav: {
+    title: 'סרגל ראשי',
+    site: 'מחיי הגניזה הקהירית',
+    about: 'אודות',
+    transcribe: 'תעתוק',
+    talk: 'פורום',
+    collect: 'יצירת אוסף'
+  },
+  scriptReferences: {
+    title: 'מאגר סוגי כתב',
+    scriptTypes: 'סוגי כתב עברי',
+    yourSheet: 'מאגר סוגי הכתב שלך',
+    types: {
+      orientalNE: '(מזרחי (צפון-מזרח המזרח התיכון',
+      orientalSW: '(מזרחי (מערב-דרום המזרח התיכון',
+      maghrebi: 'מגרבי',
+      sephardi: 'ספרדי',
+      yemenite: 'תימני',
+      byzantine: 'ביזאנטי',
+      ashkenazi: 'אשכנזי',
+      italian: 'איטלקי',
+      square: 'מרובע',
+      miniscule: 'בינוני',
+      cursive: 'רהוט'
+    },
+    sendScript: 'הצג כתב זה במקלדת',
+    currentScript: 'סוג הכתב הנוכחי',
+    back: 'חזרה למקלדת',
+    changeScript: 'שנה סוג כתב',
+    changeInstructions: `
+      שנה את סוג הכתב כדי להתרשם מההבדלים במאפייני צורת האותיות בין אזורים שונים בעולם ותקופות שונות
+    `,
+    filterBy: 'סנן סוגי כתב',
+    cursive: 'רהוט',
+    miniscule: 'בינוני',
+    square: 'מרובע'
+  },
+  cribSheet: {
+    title: 'סוגי כתב',
+    instructions: '.שמור כאן גזירות מסך של סוגי אותיות לשימושך האישי',
+    instructions2: '.אם הנך רשום במערכת, התמונות ישמרו עבורך למשך כל זמן עבודתך בפרויקט',
+    addImage: 'גזירת מסך',
+    clickAdd: 'לחץ לגזירת מסך נוספת',
+    delete: 'מחק',
+    edit: 'ערוך',
+    save: 'שמור',
+    deletePrompt: '?למחוק את גזירת המסך',
+    deletePrompt2: '.פעולה זו אינה ניתנת לשחזור',
+    cancel: 'בטל מחיקה',
+    confirm: 'כן, מחק'
+  },
+  helpers: {
+    getStarted: '"כדי להתחיל, לחץ על "הוסף תעתוק',
+    click: 'כדי לתעתק, סמן את תחילת השורה וסוף השורה בעזרת העכבר',
+    draw: 'סמן את גבולות התמונה שברצונך לגזור ולשמור'
+  },
+  fieldGuide: {
+    title: 'מידע נוסף'
+  },
+  finished: {
+    title: 'סיום',
+    allTranscribed: '?האם הכל מועתק',
+    instructions: `
+      !האם תעתקת את כל שורות המסמך? גם אם לא, הכל כשורה, תרומתך מאוד עזרה
+    `,
+    whenReady: `
+      לחץ סיים ועבור לפורום כדי לדון בקטע גניזה זה עם צוות מומחי הגניזה הקהירית ועם מתנדבים אחרים, או סיים
+      כדי לעבור למסמך הבא
+    `,
+    allComplete: 'כן, כל השורות הועתקו',
+    notFinished: 'לא, ישנן שורות שלא הועתקו',
+    cancel: 'בטל',
+    done: 'סיים',
+    doneAndTalk: 'סיים ועבור לפורום'
+  }
+};

--- a/src/locales/he.js
+++ b/src/locales/he.js
@@ -99,7 +99,8 @@ export default {
     deletePrompt: '?למחוק את גזירת המסך',
     deletePrompt2: '.פעולה זו אינה ניתנת לשחזור',
     cancel: 'בטל מחיקה',
-    confirm: 'כן, מחק'
+    confirm: 'כן, מחק',
+    deny: 'No, continue transcribing'
   },
   helpers: {
     getStarted: '"כדי להתחיל, לחץ על "הוסף תעתוק',

--- a/src/locales/he.js
+++ b/src/locales/he.js
@@ -63,8 +63,8 @@ export default {
     scriptTypes: 'סוגי כתב עברי',
     yourSheet: 'מאגר סוגי הכתב שלך',
     types: {
-      orientalNE: '(מזרחי (צפון-מזרח המזרח התיכון',
-      orientalSW: '(מזרחי (מערב-דרום המזרח התיכון',
+      orientalne: '(מזרחי (צפון-מזרח המזרח התיכון',
+      orientalsw: '(מזרחי (מערב-דרום המזרח התיכון',
       maghrebi: 'מגרבי',
       sephardi: 'ספרדי',
       yemenite: 'תימני',

--- a/src/styles/components/collections-manager.styl
+++ b/src/styles/components/collections-manager.styl
@@ -20,7 +20,7 @@
     justify-content: space-between
 
     > div:first-child
-      width: 18.5rem
+      width: 17.5rem
 
   &__create
     display: flex
@@ -29,7 +29,7 @@
     input
       border: 1px solid $plum
       padding: 0.5rem
-      width: 18.5rem
+      width: 17.5rem
 
   &__instructions
     margin-bottom: 0.25rem

--- a/src/styles/components/dialog.styl
+++ b/src/styles/components/dialog.styl
@@ -42,6 +42,7 @@
     &__header
       display: flex
       flex-direction: column
+      left: 0
       position: fixed
       width: 100%
       z-index: 1

--- a/src/styles/components/project-header.styl
+++ b/src/styles/components/project-header.styl
@@ -1,12 +1,14 @@
 .project-header
   padding-bottom: 0 !important
 
+  .active-language
+    background-color: $sand
+
   &__link
     text-decoration: none
 
     &:hover, &:focus
       background-color: $sand
-      color: $dust
 
   > div:first-child
     border: 20px solid white
@@ -61,6 +63,3 @@
     height: 1.5rem
     margin: auto
     width: 1.5rem
-
-    &:hover, &:focus
-      background-color: $sand

--- a/src/styles/components/script-references.styl
+++ b/src/styles/components/script-references.styl
@@ -14,13 +14,14 @@
     .text-link
       background: none
       border: none
+      font-size: 0.8rem
 
     .h1-font
       font-size: 1rem
       line-height: inherit
 
     > div:first-child
-      flex-basis: 40%
+      flex-basis: 45%
       padding-right: 1rem
 
       div
@@ -29,7 +30,7 @@
 
     > div:last-child
       border-left: 3px solid $plum
-      flex-basis: 60%
+      flex-basis: 55%
       padding-left: 1rem
 
       span
@@ -99,7 +100,7 @@
       font-family: $merriweather
       font-weight: 700
       color: $dust
-      margin-right: 0.75rem
+      margin: 0 0.75rem
 
     > span:nth-child(2)
       color: $dust

--- a/src/styles/components/selected-annotation.styl
+++ b/src/styles/components/selected-annotation.styl
@@ -29,6 +29,9 @@
     span:first-child
       font-weight: 600
 
+    span:last-child
+      margin: 0 0.25rem
+
   .input-box
     @extend .body-font
     border: 1px solid $plum


### PR DESCRIPTION
This PR sets up translations for the app and adds translations for the subject viewer. More translations will need to be added eventually for other content on the page. I decided to use `react-localize-redux` rather than `counterpart` because the former worked better with changing the language state and translations through Redux.

There are a few translations missing for the subject viewer which will need to be added eventually.