### PR TITLE
SubmitClassification Modal

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';
 import { ZooHeader, ZooFooter } from 'zooniverse-react-components';
-import { fetchResources } from '../ducks/initialize';
 
+import { fetchResources } from '../ducks/initialize';
+import { generateSessionID } from '../lib/get-session-id';
 import AboutLayout from './about';
 import AuthContainer from '../containers/AuthContainer';
 import ClassifierContainer from '../containers/ClassifierContainer';
@@ -15,6 +16,10 @@ import ProjectHeader from './ProjectHeader';
 class App extends React.Component {
   componentWillMount() {
     this.props.dispatch(fetchResources());
+  }
+
+  componentDidMount() {
+    generateSessionID();
   }
 
   render() {

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -8,6 +8,7 @@ import { fetchGuide } from '../ducks/field-guide';
 import { toggleDialog } from '../ducks/dialog';
 import FieldGuide from '../components/FieldGuide';
 import CribSheet from '../components/CribSheet';
+import FinishedPrompt from '../components/FinishedPrompt';
 import { fetchTutorial, TUTORIAL_STATUS } from '../ducks/tutorial';
 
 class ControlPanel extends React.Component {
@@ -23,6 +24,7 @@ class ControlPanel extends React.Component {
     this.toggleInfo = this.toggleInfo.bind(this);
     this.togglePanel = this.togglePanel.bind(this);
     this.toggleCribSheet = this.toggleCribSheet.bind(this);
+    this.finishedPrompt = this.finishedPrompt.bind(this);
 
     this.state = {
       showPanel: true,
@@ -112,6 +114,12 @@ class ControlPanel extends React.Component {
     this.setState({ showPanel: !this.state.showPanel });
   }
 
+  finishedPrompt() {
+    this.props.dispatch(toggleDialog(
+      <FinishedPrompt />, 'Finished'
+    ));
+  }
+
   showSubjectInfo() {
     return (
       <div className="control-panel__info">
@@ -176,7 +184,7 @@ class ControlPanel extends React.Component {
           <div>
             <button className="button">Transcribe Page Reverse</button>
             <button className="button">Save Progress</button>
-            <button className="button button__dark">Done</button>
+            <button className="button button__dark" onClick={this.finishedPrompt}>Done</button>
           </div>
         </div>
       </Section>

--- a/src/components/FinishedPrompt.jsx
+++ b/src/components/FinishedPrompt.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { toggleDialog } from '../ducks/dialog';
+
+class FinishedPrompt extends React.Component {
+  constructor() {
+    super();
+
+    this.onCancel = this.onCancel.bind(this);
+    this.onDone = this.onDone.bind(this);
+    this.onDoneAndTalk = this.onDoneAndTalk.bind(this);
+  }
+
+  onCancel() {
+    this.props.dispatch(toggleDialog(null));
+  }
+
+  onDone() {
+    console.log('done');
+  }
+
+  onDoneAndTalk() {
+    console.log('talk');
+  }
+
+  render() {
+    return (
+      <div className="finished-prompt handle">
+        <h2 className="h1-font">Has everything been transcribed?</h2>
+        <div className="finished-prompt__content">
+          <span className="body-font">
+            Has every line in this document been transcribed? Don&apos;t worry if
+            some lines remain; your contributions are appreciated!
+          </span>
+          <span className="body-font">
+            When you&apos;re ready, click <b>Done & Talk</b> to discuss this document
+            with the Cairo Geniza research team and your fellow volunteers, or
+            <b> Done</b> to go to the next document.
+          </span>
+        </div>
+        <div className="finished-prompt__toggle">
+          <div className="round-toggle">
+            <input
+              id="allDone"
+              type="checkbox"
+              ref={(el) => { this.allDone = el; }}
+              defaultChecked={false}
+            />
+            <label className="primary-label" htmlFor="allDone">
+              <span>Yes, all lines are complete</span>
+            </label>
+          </div>
+          <div className="round-toggle">
+            <input
+              id="notDone"
+              type="checkbox"
+              ref={(el) => { this.notDone = el; }}
+              defaultChecked={false}
+            />
+            <label className="primary-label" htmlFor="notDone">
+              <span>No, some lines have not been transcribed</span>
+            </label>
+          </div>
+        </div>
+        <div className="finished-prompt__buttons">
+          <button className="button" onClick={this.onCancel}>Cancel</button>
+          <button className="button" onClick={this.onDone}>Done</button>
+          <button className="button button__dark" onClick={this.onDoneAndTalk}>Done & Talk</button>
+        </div>
+      </div>
+    );
+  }
+}
+
+FinishedPrompt.propTypes = {
+  dispatch: PropTypes.func
+};
+
+FinishedPrompt.defaultProps = {
+  dispatch: () => {}
+};
+
+export default connect()(FinishedPrompt);

--- a/src/config.js
+++ b/src/config.js
@@ -25,7 +25,7 @@ const baseConfig = {
     host: '',
     projectId: '1814',
     projectSlug: '',
-    workflowId: '3156'
+    workflowId: '3157'
   },
   production: {
     panoptesAppId: '',

--- a/src/config.js
+++ b/src/config.js
@@ -22,16 +22,16 @@ if (!env.match(/^(production|staging|development)$/)) {
 const baseConfig = {
   development: {
     panoptesAppId: 'c71ef0db12dde9e5d8852e7bbc239ef868990d0893cd52c7d47370f90d3992b0',  //Scribes of the Cairo Geniza on Staging
-    host: '',
+    host: 'https://master.pfe-preview.zooniverse.org/',
     projectId: '1814',
-    projectSlug: '',
+    projectSlug: 'wgranger-test/scribes-of-the-cairo-geniza-testing',
     workflowId: '3157'
   },
   production: {
     panoptesAppId: '',
-    host: '',
+    host: 'https://www.zooniverse.org/',
     projectId: '5042',
-    projectSlug: '',
+    projectSlug: 'judaicadh/scribes-of-the-cairo-geniza',
     workflowId: ''
   }
 };

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { fetchQueue } from '../ducks/subject';
+import { fetchSubject } from '../ducks/subject';
 
 import ControlPanel from '../components/ControlPanel';
 import Toolbar from '../components/Toolbar';
@@ -9,7 +9,7 @@ import SubjectViewer from './SubjectViewer';
 
 class ClassifierContainer extends React.Component {
   componentWillMount() {
-    this.props.dispatch(fetchQueue());
+    this.props.dispatch(fetchSubject());
   }
 
   render() {

--- a/src/ducks/annotations.js
+++ b/src/ducks/annotations.js
@@ -6,6 +6,7 @@ const UPDATE_TEXT = 'UPDATE_TEXT';
 const SELECT_ANNOTATION = 'SELECT_ANNOTATION';
 const UNSELECT_ANNOTATION = 'UNSELECT_ANNOTATION';
 const DELETE_SELECTED_ANNOTATION = 'DELETE_SELECTED_ANNOTATION';
+const RESET_ANNOTATIONS = 'RESET_ANNOTATIONS';
 
 const ANNOTATION_STATUS = {
   IDLE: 'annotation_status_idle',
@@ -23,6 +24,9 @@ const initialState = {
 
 const annotationsReducer = (state = initialState, action) => {
   switch (action.type) {
+    case RESET_ANNOTATIONS:
+      return initialState;
+
     case ADD_ANNOTATION_POINT: {
       const annotationInProgress = (state.annotationInProgress)
         ? Object.assign({}, state.annotationInProgress)
@@ -160,10 +164,16 @@ const deleteSelectedAnnotation = () => {
   };
 };
 
+const resetAnnotations = () => {
+  return (dispatch) => {
+    dispatch({ type: RESET_ANNOTATIONS });
+  };
+};
+
 export default annotationsReducer;
 
 export {
   addAnnotationPoint, completeAnnotation,
-  deleteSelectedAnnotation, selectAnnotation,
-  updateText, unselectAnnotation
+  deleteSelectedAnnotation, resetAnnotations,
+  selectAnnotation, updateText, unselectAnnotation
 };

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -1,6 +1,7 @@
 import apiClient from 'panoptes-client/lib/api-client';
 import { config } from '../config';
 import { createClassification } from './classification';
+import { resetAnnotations } from './annotations';
 
 // Action Types
 const FETCH_SUBJECT = 'FETCH_SUBJECT';
@@ -54,6 +55,7 @@ const subjectReducer = (state = initialState, action) => {
 };
 
 const prepareForNewSubject = (dispatch, subject) => {
+  dispatch(resetAnnotations());
   dispatch(createClassification(subject));
 };
 

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -35,7 +35,6 @@ const subjectReducer = (state = initialState, action) => {
         queue: action.queue,
         currentSubject: action.currentSubject,
         favorite: action.favorite,
-        queue: action.queue,
         status: SUBJECT_STATUS.READY
       });
 
@@ -58,27 +57,49 @@ const prepareForNewSubject = (dispatch, subject) => {
   dispatch(createClassification(subject));
 };
 
-const fetchQueue = (id = config.workflowId) => {
-  return (dispatch) => {
-    dispatch({
-      type: FETCH_SUBJECT
-    });
+const fetchSubject = (initialFetch = false) => {
+  return (dispatch, getState) => {
+    if (initialFetch && getState().subject.status !== SUBJECT_STATUS.IDLE) return;
+    const workflow_id = getState().workflow.id;
 
-    apiClient.type('subjects/queued').get({ workflow_id: id })
-      .then((queue) => {
-        const currentSubject = queue.shift();
-        dispatch({
-          currentSubject,
-          favorite: currentSubject.favorite || false,
-          type: FETCH_SUBJECT_SUCCESS,
-          queue
+    dispatch({ type: FETCH_SUBJECT });
+
+    const subjectQuery = { workflow_id };
+
+    const fetchQueue = () => {
+      apiClient.type('subjects/queued').get(subjectQuery)
+        .then((queue) => {
+          const currentSubject = queue.shift();
+          dispatch({
+            currentSubject,
+            id: currentSubject.id,
+            queue,
+            type: FETCH_SUBJECT_SUCCESS,
+            favorite: currentSubject.favorite || false
+          });
+
+          prepareForNewSubject(dispatch, currentSubject);
+        })
+        .catch((err) => {
+          console.error('ducks/subject.js fetchSubject() error: ', err);
+          dispatch({ type: FETCH_SUBJECT_ERROR });
         });
-        prepareForNewSubject(dispatch, currentSubject);
-      })
-      .catch((err) => {
-        console.error('ducks/subject.js fetchSubject() error: ', err);
-        dispatch({ type: FETCH_SUBJECT_ERROR });
+    };
+
+    if (!getState().subject.queue.length) {
+      fetchQueue();
+    } else {
+      const currentSubject = getState().subject.queue.shift();
+      dispatch({
+        currentSubject,
+        id: currentSubject.id,
+        queue: getState().subject.queue,
+        type: FETCH_SUBJECT_SUCCESS,
+        favorite: currentSubject.favorite || false
       });
+
+      prepareForNewSubject(dispatch, currentSubject);
+    }
   };
 };
 
@@ -135,7 +156,7 @@ const toggleFavorite = () => {
 export default subjectReducer;
 
 export {
-  fetchQueue,
+  fetchSubject,
   subjectError,
   toggleFavorite,
   SUBJECT_STATUS

--- a/src/lib/get-session-id.js
+++ b/src/lib/get-session-id.js
@@ -1,0 +1,43 @@
+let stored = sessionStorage.getItem('session_id') || null;
+
+const twoHoursFromNow = () => {
+  const d = new Date();
+  d.setHours(d.getHours() + 2);
+  return d;
+};
+
+const generateSessionID = () => {
+  const hash = require('hash.js');
+  const sha2 = hash.sha256();
+  const id = sha2.update(`${Math.random() * 10000}${Date.now()}${Math.random() * 1000}`).digest('hex');
+  const ttl = twoHoursFromNow();
+  stored = { id, ttl };
+  try {
+    sessionStorage.setItem('session_id', JSON.stringify(stored));
+  } catch (err) {
+    console.error('lib/get-session-id.js generateSessionID() error: ', err);
+  }
+  return stored;
+};
+
+const getSessionID = () => {
+  let id;
+  let ttl;
+  if (stored) {
+    ({ id, ttl } = JSON.parse(sessionStorage.getItem('session_id')));
+  }
+
+  if (new Date(ttl).getTime() < Date.now()) {
+    id = generateSessionID();
+  } else {
+    ttl = twoHoursFromNow();
+    try {
+      sessionStorage.setItem('session_id', JSON.stringify({ id, ttl }));
+    } catch (err) {
+      console.error('lib/get-session-id.js getSessionID() error: ', err);
+    }
+  }
+  return id;
+};
+
+export { generateSessionID, getSessionID };

--- a/src/styles/components/finished-prompt.styl
+++ b/src/styles/components/finished-prompt.styl
@@ -1,0 +1,27 @@
+.finished-prompt
+  margin: 4rem 1.5rem 1.5rem 1.5rem
+
+  &__content
+    span
+      display: block
+      margin-bottom: 1rem
+
+    b
+      font-weight: 700
+
+  &__toggle
+    height: 5rem
+    margin: 1rem 0
+
+    .round-toggle
+      margin: 0.5rem 0
+
+    span
+      width: 20rem
+
+  &__buttons
+    display: flex
+    justify-content: space-between
+
+    button
+      width: 10.5rem

--- a/src/styles/components/finished-prompt.styl
+++ b/src/styles/components/finished-prompt.styl
@@ -26,3 +26,10 @@
 
     button
       width: 10.5rem
+
+      &:disabled
+        background-image: url('../images/bg-disabled-secondary.png')
+        cursor: default
+
+    .button__dark:disabled
+      background-image: url('../images/bg-disabled.png')

--- a/src/styles/components/finished-prompt.styl
+++ b/src/styles/components/finished-prompt.styl
@@ -17,6 +17,7 @@
       margin: 0.5rem 0
 
     span
+      @extend .primary-label
       width: 20rem
 
   &__buttons

--- a/src/styles/global/round-toggle.styl
+++ b/src/styles/global/round-toggle.styl
@@ -19,7 +19,7 @@
     border: 1px solid $plum
     border-radius: 50%
 
-  input[type="checkbox"]:checked + label
+  input[type="checkbox"]:checked + label, input[type="radio"]:checked + label
     background-color: $plum
 
   input


### PR DESCRIPTION
This should contain all of the functionality needed to confirm a classification can be submitted. 

The modal is similar to the component on ASM, with a couple exceptions.

1) Functionality does not yet exist to save a classification. Instead, this branch contains a bare bones version of classification submission. I'd like to revisit saved classifications anew in a future PR.

2) You may note some hard-coded text in the `FinishedPrompt` where the question is typed. In ASM, this text is retrieved directly from the workflow resource. In this PR, the text is hardcoded for styling reasons (paragraph break). 