### PR TITLE
"Save Progress" feature

### DIFF
--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -8,7 +8,10 @@ import { getTranslate, getActiveLanguage } from 'react-localize-redux';
 
 import { fetchGuide } from '../ducks/field-guide';
 import { toggleDialog, togglePopup } from '../ducks/dialog';
-import { WorkInProgress } from '../ducks/work-in-progress';
+import {
+  WorkInProgress, WORKINPROGRESS_INITIAL_STATE, WORKINPROGRESS_PROPTYPES,
+  getWorkInProgressStateValues
+} from '../ducks/work-in-progress';
 import FieldGuide from '../components/FieldGuide';
 import CribSheet from '../components/CribSheet';
 import TutorialView from '../components/TutorialView';
@@ -194,6 +197,15 @@ class ControlPanel extends React.Component {
           )}
 
           <hr className="white-line" />
+
+          <div>
+            <button className="button">{this.props.translate('infoBox.transcribeReverse')}</button>
+            <button className="button" onClick={()=>{this.props.dispatch(WorkInProgress.save())}}>
+              {this.props.translate('infoBox.saveProgress')}
+            </button>
+            {this.props.wipTimestamp && (<div className="workinprogress-timestamp">{this.props.wipTimestamp.toString()}</div>)}
+            <button className="button button__dark" onClick={this.finishedPrompt}>{this.props.translate('infoBox.finished')}</button>
+          </div>
           
           <div>
             <button className="button" onClick={()=>{
@@ -204,20 +216,11 @@ class ControlPanel extends React.Component {
               this.props.dispatch(WorkInProgress.clear());
             }}>DEBUG CLEAR</button>
             <button className="button" onClick={()=>{
-              console.log('WorkInProgress.save()');
-              this.props.dispatch(WorkInProgress.save());
-            }}>DEBUG SAVE</button>
-            <button className="button" onClick={()=>{
               console.log('WorkInProgress.load()');
               this.props.dispatch(WorkInProgress.load());
             }}>DEBUG LOAD</button>
           </div>
-
-          <div>
-            <button className="button">{this.props.translate('infoBox.transcribeReverse')}</button>
-            <button className="button">{this.props.translate('infoBox.saveProgress')}</button>
-            <button className="button button__dark" onClick={this.finishedPrompt}>{this.props.translate('infoBox.finished')}</button>
-          </div>
+          
         </div>
       </Section>
     );
@@ -268,7 +271,8 @@ ControlPanel.propTypes = {
   }),
   workflow: PropTypes.shape({
     id: PropTypes.string
-  })
+  }),
+  ...WORKINPROGRESS_PROPTYPES
 };
 
 ControlPanel.defaultProps = {
@@ -283,7 +287,8 @@ ControlPanel.defaultProps = {
   tutorial: null,
   tutorialStatus: TUTORIAL_STATUS.IDLE,
   user: null,
-  workflow: null
+  workflow: null,
+  ...WORKINPROGRESS_INITIAL_STATE,
 };
 
 const mapStateToProps = (state) => {
@@ -299,7 +304,8 @@ const mapStateToProps = (state) => {
     tutorial: state.tutorial.data,
     tutorialStatus: state.tutorial.status,
     user: state.login.user,
-    workflow: state.workflow.data
+    workflow: state.workflow.data,
+    ...getWorkInProgressStateValues(state),
   };
 };
 

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -8,6 +8,7 @@ import { getTranslate, getActiveLanguage } from 'react-localize-redux';
 
 import { fetchGuide } from '../ducks/field-guide';
 import { toggleDialog, togglePopup } from '../ducks/dialog';
+import { WorkInProgress } from '../ducks/work-in-progress';
 import FieldGuide from '../components/FieldGuide';
 import CribSheet from '../components/CribSheet';
 import TutorialView from '../components/TutorialView';
@@ -193,6 +194,21 @@ class ControlPanel extends React.Component {
           )}
 
           <hr className="white-line" />
+          
+          <div>
+            <button className="button" onClick={()=>{
+              console.log('WorkInProgress.check(): ', WorkInProgress.check(this.props.user));
+            }}>DEBUG CHECK</button>
+            <button className="button" onClick={()=>{
+              this.props.dispatch(WorkInProgress.clear());
+            }}>DEBUG CLEAR</button>
+            <button className="button" onClick={()=>{
+              this.props.dispatch(WorkInProgress.save());
+            }}>DEBUG SAVE</button>
+            <button className="button" onClick={()=>{
+              this.props.dispatch(WorkInProgress.load());
+            }}>DEBUG LOAD</button>
+          </div>
 
           <div>
             <button className="button">{this.props.translate('infoBox.transcribeReverse')}</button>

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -200,12 +200,15 @@ class ControlPanel extends React.Component {
               console.log('WorkInProgress.check(): ', WorkInProgress.check(this.props.user));
             }}>DEBUG CHECK</button>
             <button className="button" onClick={()=>{
+              console.log('WorkInProgress.clear()');
               this.props.dispatch(WorkInProgress.clear());
             }}>DEBUG CLEAR</button>
             <button className="button" onClick={()=>{
+              console.log('WorkInProgress.save()');
               this.props.dispatch(WorkInProgress.save());
             }}>DEBUG SAVE</button>
             <button className="button" onClick={()=>{
+              console.log('WorkInProgress.load()');
               this.props.dispatch(WorkInProgress.load());
             }}>DEBUG LOAD</button>
           </div>

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -47,6 +47,12 @@ class ControlPanel extends React.Component {
 
   componentDidMount() {
     this.fetchTutorial(this.props);
+    
+    //Check if the user has any work in progress.
+    //componentDidMount() checks when the user accesses the Classifier page from another page, e.g. the Home page. 
+    if (this.props.user && WorkInProgress.check(this.props.user)) {
+      this.props.dispatch(togglePopup(<WorkInProgressPopup />));
+    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -60,10 +66,9 @@ class ControlPanel extends React.Component {
       });
     }
     
-    //Now check if the user has any work in progress.
-    console.log('+++ componentWillReceiveProps', this.props.user !== nextProps.user, WorkInProgress.check(nextProps.user));
-    if (this.props.user !== nextProps.user && WorkInProgress.check(nextProps.user)) {
-      console.log('+++ WorkInProgressPopup', nextProps.user);
+    //Check if the user has any work in progress.
+    //componentWillReceiveProps() checks when the user accesses the Classifier page directly. 
+    if (this.props.user !== nextProps.user && nextProps.user && WorkInProgress.check(nextProps.user)) {
       this.props.dispatch(togglePopup(<WorkInProgressPopup />));
     }
     

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -219,8 +219,8 @@ class ControlPanel extends React.Component {
                 {this.props.translate('infoBox.saveProgress')}
               </button>
             )}
-            {this.props.wipTimestamp && (<div className="workinprogress-timestamp">{'Last save: ' + this.props.wipTimestamp.toString()}</div>)}
             <button className="button button__dark" onClick={this.finishedPrompt}>{this.props.translate('infoBox.finished')}</button>
+            {this.props.wipTimestamp && (<div className="workinprogress-timestamp body-font">{this.props.translate('infoBox.lastSave') + ': ' + this.props.wipTimestamp.toString()}</div>)}
           </div>
 
         </div>

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -61,9 +61,10 @@ class ControlPanel extends React.Component {
     }
     
     //Now check if the user has any work in progress.
+    console.log('+++ componentWillReceiveProps', this.props.user !== nextProps.user, WorkInProgress.check(nextProps.user));
     if (this.props.user !== nextProps.user && WorkInProgress.check(nextProps.user)) {
-      console.log('+'.repeat(100), nextProps.user);
-      return this.props.dispatch(togglePopup(<WorkInProgressPopup />));
+      console.log('+++ WorkInProgressPopup', nextProps.user);
+      this.props.dispatch(togglePopup(<WorkInProgressPopup />));
     }
     
     window.addEventListener('resize', this.handleResize);
@@ -92,7 +93,7 @@ class ControlPanel extends React.Component {
 
   toggleTutorial() {
     if (this.props.dialogComponent === 'Tutorial') {
-      return this.props.dispatch(togglePopup(null));
+      this.props.dispatch(togglePopup(null));
     }
 
     if (this.props.tutorial) {
@@ -208,27 +209,15 @@ class ControlPanel extends React.Component {
 
           <div>
             <button className="button">{this.props.translate('infoBox.transcribeReverse')}</button>
-            <button className="button" onClick={()=>{this.props.dispatch(WorkInProgress.save())}}>
-              {this.props.translate('infoBox.saveProgress')}
-            </button>
-            {this.props.wipTimestamp && (<div className="workinprogress-timestamp">{this.props.wipTimestamp.toString()}</div>)}
+            {this.props.user && (  //Show the Save Progress button to logged-in users only.
+              <button className="button" onClick={()=>{this.props.dispatch(WorkInProgress.save())}}>
+                {this.props.translate('infoBox.saveProgress')}
+              </button>
+            )}
+            {this.props.wipTimestamp && (<div className="workinprogress-timestamp">{'Last save: ' + this.props.wipTimestamp.toString()}</div>)}
             <button className="button button__dark" onClick={this.finishedPrompt}>{this.props.translate('infoBox.finished')}</button>
           </div>
-          
-          <div>
-            <button className="button" onClick={()=>{
-              console.log('WorkInProgress.check(): ', WorkInProgress.check(this.props.user));
-            }}>DEBUG CHECK</button>
-            <button className="button" onClick={()=>{
-              console.log('WorkInProgress.clear()');
-              this.props.dispatch(WorkInProgress.clear());
-            }}>DEBUG CLEAR</button>
-            <button className="button" onClick={()=>{
-              console.log('WorkInProgress.load()');
-              this.props.dispatch(WorkInProgress.load());
-            }}>DEBUG LOAD</button>
-          </div>
-          
+
         </div>
       </Section>
     );

--- a/src/components/WorkInProgressPopup.jsx
+++ b/src/components/WorkInProgressPopup.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { getTranslate } from 'react-localize-redux';
+
 import { togglePopup } from '../ducks/dialog';
 import { WorkInProgress } from '../ducks/work-in-progress';
 
@@ -34,15 +36,14 @@ class WorkInProgressPopup extends React.Component {
           <hr className="pseudo-drag-bar" />
           <div className="work-in-progress-popup__content">
             <div className="work-in-progress-popup__message">
-              <h2 className="h1-font">Resume Work In Progress?</h2>
+              <h2 className="h1-font">{this.props.translate('workInProgress.header')}</h2>
               <p>
-                We detected that you have some work in progress saved.
-                You can continue your saved work, or start with a new page.
+                {this.props.translate('workInProgress.message')}
               </p>
             </div>
             <div className="work-in-progress-popup__controls">
-              <button className="button" onClick={this.startNewWork}>New Page</button>
-              <button className="button button__dark" onClick={this.resumeWorkInProgress}>Resume Work</button>
+              <button className="button" onClick={this.startNewWork}>{this.props.translate('workInProgress.startNewWork')}</button>
+              <button className="button button__dark" onClick={this.resumeWorkInProgress}>{this.props.translate('workInProgress.resumeWorkInProgress')}</button>
             </div>
           </div>
         </div>
@@ -53,10 +54,18 @@ class WorkInProgressPopup extends React.Component {
 
 WorkInProgressPopup.propTypes = {
   dispatch: PropTypes.func,
+  translate: PropTypes.func,
 };
 
 WorkInProgressPopup.defaultProps = {
   dispatch: () => {},
+  translate: () => {},
 };
 
-export default connect()(WorkInProgressPopup);
+const mapStateToProps = (state) => {
+  return {
+    translate: getTranslate(state.locale)
+  };
+};
+
+export default connect(mapStateToProps)(WorkInProgressPopup);

--- a/src/components/WorkInProgressPopup.jsx
+++ b/src/components/WorkInProgressPopup.jsx
@@ -31,16 +31,19 @@ class WorkInProgressPopup extends React.Component {
     return (
       <div className="work-in-progress-popup-container">
         <div className="work-in-progress-popup">
-          <div className="work-in-progress-popup__message">
-            <span className="work-in-progress-popup__header">Resume Work In Progress?</span>
-            <p>
-              We detected that you have some work in progress saved.
-              You can continue your saved work, or start with a new page.
-            </p>
-          </div>
-          <div>
-            <button className="button" onClick={this.startNewWork}>New Page</button>
-            <button className="button button__dark" onClick={this.resumeWorkInProgress}>Resume Work</button>
+          <hr className="pseudo-drag-bar" />
+          <div className="work-in-progress-popup__content">
+            <div className="work-in-progress-popup__message">
+              <h2 className="h1-font">Resume Work In Progress?</h2>
+              <p>
+                We detected that you have some work in progress saved.
+                You can continue your saved work, or start with a new page.
+              </p>
+            </div>
+            <div className="work-in-progress-popup__controls">
+              <button className="button" onClick={this.startNewWork}>New Page</button>
+              <button className="button button__dark" onClick={this.resumeWorkInProgress}>Resume Work</button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/WorkInProgressPopup.jsx
+++ b/src/components/WorkInProgressPopup.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { togglePopup } from '../ducks/dialog';
+import { WorkInProgress } from '../ducks/work-in-progress';
+
+class WorkInProgressPopup extends React.Component {
+  constructor() {
+    super();
+
+    this.closePopup = this.closePopup.bind(this);
+    this.resumeWorkInProgress = this.resumeWorkInProgress.bind(this);
+    this.startNewWork = this.startNewWork.bind(this);
+  }
+
+  closePopup() {
+    this.props.dispatch(togglePopup(null));
+  }
+  
+  resumeWorkInProgress() {
+    this.props.dispatch(WorkInProgress.load());
+    this.closePopup();
+  }
+  
+  startNewWork() {
+    this.props.dispatch(WorkInProgress.clear());
+    this.closePopup();
+  }
+
+  render() {
+    return (
+      <div className="work-in-progress-popup">
+        <p>
+          We detected that you have some work in progress saved.
+          You can continue your saved work, or start with a new page.
+        </p>
+        <div>
+          <button className="button" onClick={this.startNewWork}>New Page</button>
+          <button className="button button__dark" onClick={this.resumeWorkInProgress}>Resume Work</button>
+        </div>
+      </div>
+    );
+  }
+}
+
+WorkInProgressPopup.propTypes = {
+  dispatch: PropTypes.func,
+};
+
+WorkInProgressPopup.defaultProps = {
+  dispatch: () => {},
+};
+
+export default connect()(WorkInProgressPopup);

--- a/src/components/WorkInProgressPopup.jsx
+++ b/src/components/WorkInProgressPopup.jsx
@@ -29,14 +29,19 @@ class WorkInProgressPopup extends React.Component {
 
   render() {
     return (
-      <div className="work-in-progress-popup">
-        <p>
-          We detected that you have some work in progress saved.
-          You can continue your saved work, or start with a new page.
-        </p>
-        <div>
-          <button className="button" onClick={this.startNewWork}>New Page</button>
-          <button className="button button__dark" onClick={this.resumeWorkInProgress}>Resume Work</button>
+      <div className="work-in-progress-popup-container">
+        <div className="work-in-progress-popup">
+          <div className="work-in-progress-popup__message">
+            <span className="work-in-progress-popup__header">Resume Work In Progress?</span>
+            <p>
+              We detected that you have some work in progress saved.
+              You can continue your saved work, or start with a new page.
+            </p>
+          </div>
+          <div>
+            <button className="button" onClick={this.startNewWork}>New Page</button>
+            <button className="button button__dark" onClick={this.resumeWorkInProgress}>Resume Work</button>
+          </div>
         </div>
       </div>
     );

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -35,7 +35,6 @@ class ClassifierContainer extends React.Component {
 
 const mapStateToProps = (state) => {
   return {
-    currentSubject: state.subject.currentSubject,
     subjectStatus: state.subject.status,
   };
 };

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { fetchSubject } from '../ducks/subject';
+import {
+  fetchSubject, SUBJECT_STATUS,
+} from '../ducks/subject';
 
 import ControlPanel from '../components/ControlPanel';
 import Toolbar from '../components/Toolbar';
@@ -9,7 +11,15 @@ import SubjectViewer from './SubjectViewer';
 
 class ClassifierContainer extends React.Component {
   componentWillMount() {
-    this.props.dispatch(fetchSubject());
+    //TODO: check if a Workflow has been selected. Prompt the user to select
+    //one if there's none.
+  
+    //Initial Subject fetch!
+    //If we didn't check that a Subject already exists, we'd always fetch
+    //a new subject every time the user accesses the Classifier. 
+    if (this.props.subjectStatus === SUBJECT_STATUS.IDLE) {
+      this.props.dispatch(fetchSubject());
+    }
   }
 
   render() {
@@ -23,4 +33,11 @@ class ClassifierContainer extends React.Component {
   }
 }
 
-export default connect()(ClassifierContainer);
+const mapStateToProps = (state) => {
+  return {
+    currentSubject: state.subject.currentSubject,
+    subjectStatus: state.subject.status,
+  };
+};
+
+export default connect(mapStateToProps)(ClassifierContainer);

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -353,7 +353,7 @@ class SubjectViewer extends React.Component {
       >
         {renderedItem}
 
-        {this.props.popup && (this.props.popup)}
+        {this.props.popup}
       </section>
     );
   }

--- a/src/ducks/annotations.js
+++ b/src/ducks/annotations.js
@@ -7,6 +7,7 @@ const SELECT_ANNOTATION = 'SELECT_ANNOTATION';
 const UNSELECT_ANNOTATION = 'UNSELECT_ANNOTATION';
 const DELETE_SELECTED_ANNOTATION = 'DELETE_SELECTED_ANNOTATION';
 const RESET_ANNOTATIONS = 'RESET_ANNOTATIONS';
+const LOAD_ANNOTATIONS = 'LOAD_ANNOTATIONS';
 
 const ANNOTATION_STATUS = {
   IDLE: 'annotation_status_idle',
@@ -26,6 +27,16 @@ const annotationsReducer = (state = initialState, action) => {
   switch (action.type) {
     case RESET_ANNOTATIONS:
       return initialState;
+    
+    case LOAD_ANNOTATIONS:
+      return {
+        annotationInProgress: null,
+        annotationBoxPosition: null,
+        annotations: action.annotations,
+        selectedAnnotation: null,
+        selectedAnnotationIndex: null,
+        status: ANNOTATION_STATUS.IDLE
+      };
 
     case ADD_ANNOTATION_POINT: {
       const annotationInProgress = (state.annotationInProgress)
@@ -164,6 +175,14 @@ const deleteSelectedAnnotation = () => {
   };
 };
 
+/*  Loads existing annotations data, usually via the WorkInProgress library.
+ */
+const loadAnnotations = (annotations) => {
+  return (dispatch) => {
+    dispatch({ type: LOAD_ANNOTATIONS, annotations });
+  };
+};
+
 const resetAnnotations = () => {
   return (dispatch) => {
     dispatch({ type: RESET_ANNOTATIONS });
@@ -174,6 +193,6 @@ export default annotationsReducer;
 
 export {
   addAnnotationPoint, completeAnnotation,
-  deleteSelectedAnnotation, resetAnnotations,
+  deleteSelectedAnnotation, loadAnnotations, resetAnnotations,
   selectAnnotation, updateText, unselectAnnotation
 };

--- a/src/ducks/classification.js
+++ b/src/ducks/classification.js
@@ -2,6 +2,7 @@ import apiClient from 'panoptes-client/lib/api-client';
 import counterpart from 'counterpart';
 import { config } from '../config';
 import { fetchSubject } from './subject';
+import { WorkInProgress } from './work-in-progress';
 import { resetView } from './subject-viewer';
 import { getSessionID } from '../lib/get-session-id';
 
@@ -145,6 +146,7 @@ const saveAllQueuedClassifications = (dispatch, user = null) => {
         dispatch({ type: SUBMIT_CLASSIFICATION_FINISHED });
         dispatch(fetchSubject());
         dispatch(resetView());
+        dispatch(WorkInProgress.clear());  //Clear the Work In Progress ONLY after all Subjects have successfully been submitted.
       }
     };
 

--- a/src/ducks/initialize.js
+++ b/src/ducks/initialize.js
@@ -43,9 +43,6 @@ const fetchResources = () => {
     dispatch({ type: FETCH_RESOURCES });
     dispatch(initializeLanguages());
 
-    console.log('a'.repeat(100), dispatch(fetchProject()));
-    console.log('b'.repeat(100), dispatch(fetchWorkflow()));
-    
     Promise.all([
       dispatch(fetchProject()),
       dispatch(fetchWorkflow()),

--- a/src/ducks/initialize.js
+++ b/src/ducks/initialize.js
@@ -43,6 +43,9 @@ const fetchResources = () => {
     dispatch({ type: FETCH_RESOURCES });
     dispatch(initializeLanguages());
 
+    console.log('a'.repeat(100), dispatch(fetchProject()));
+    console.log('b'.repeat(100), dispatch(fetchWorkflow()));
+    
     Promise.all([
       dispatch(fetchProject()),
       dispatch(fetchWorkflow()),

--- a/src/ducks/reducer.js
+++ b/src/ducks/reducer.js
@@ -1,20 +1,22 @@
 import { combineReducers } from 'redux';
 import { localeReducer as locale } from 'react-localize-redux';
+
+import annotations from './annotations';
+import classification from './classification';
+import collections from './collections';
+import cribSheet from './crib-sheet';
 import dialog from './dialog';
 import fieldGuide from './field-guide';
 import initialize from './initialize';
+import keyboard from './keyboard';
+import languages from './languages';
 import login from './login';
 import project from './project';
 import subject from './subject';
 import subjectViewer from './subject-viewer';
 import tutorial from './tutorial';
 import workflow from './workflow';
-import classification from './classification';
-import annotations from './annotations';
-import collections from './collections';
-import cribSheet from './crib-sheet';
-import languages from './languages';
-import keyboard from './keyboard';
+import workInProgress from './work-in-progress';
 
 export default combineReducers({
   annotations,
@@ -32,5 +34,6 @@ export default combineReducers({
   subject,
   subjectViewer,
   tutorial,
-  workflow
+  workflow,
+  workInProgress,
 });

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -87,7 +87,7 @@ const fetchSubject = (subjectId = null) => {
       dispatch({ type: FETCH_SUBJECT, id: subjectId });
 
       //Asynchronous action
-      apiClient.type('subjects').get(subjectId)
+      return apiClient.type('subjects').get(subjectId)
         .then((currentSubject) => {
           //Store update: enter "success" state and save fetched data.
           dispatch({
@@ -118,7 +118,7 @@ const fetchSubject = (subjectId = null) => {
       //If there's an empty queue, fetch a new one.
       if (!getState().subject.queue.length) {
 
-        apiClient.type('subjects/queued').get(subjectQuery)
+        return apiClient.type('subjects/queued').get(subjectQuery)
           .then((queue) => {
             const updatedQueue = queue.slice();  //Make a copy of the queue
             const currentSubject = updatedQueue.shift();
@@ -180,7 +180,7 @@ const createFavorites = (project) => {
     display_name,
     links
   };
-  apiClient.type('collections')
+  return apiClient.type('collections')
     .create(collection)
     .save()
     .catch(err => Promise.reject(err));
@@ -195,7 +195,7 @@ const toggleFavorite = () => {
     dispatch({ type: TOGGLE_FAVORITE, favorite: !favorite });
 
     if (user) {
-      apiClient.type('collections').get({
+      return apiClient.type('collections').get({
         project_ids: projectID,
         favorite: true,
         owner: user

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -1,9 +1,11 @@
 import apiClient from 'panoptes-client/lib/api-client';
 import { config } from '../config';
-import { createClassification } from './classification';
+
 import { resetAnnotations } from './annotations';
+import { createClassification } from './classification';
 
 // Action Types
+const RESET_SUBJECT = 'FETCH_SUBJECT';
 const FETCH_SUBJECT = 'FETCH_SUBJECT';
 const FETCH_SUBJECT_SUCCESS = 'FETCH_SUBJECT_SUCCESS';
 const FETCH_SUBJECT_ERROR = 'FETCH_SUBJECT_ERROR';
@@ -27,6 +29,9 @@ const initialState = {
 
 const subjectReducer = (state = initialState, action) => {
   switch (action.type) {
+    case RESET_SUBJECT:
+      return initialState;
+
     case FETCH_SUBJECT:
       return Object.assign({}, state, {
         currentSubject: null,
@@ -62,11 +67,6 @@ const subjectReducer = (state = initialState, action) => {
   }
 };
 
-const prepareForNewSubject = (dispatch, subject) => {
-  dispatch(resetAnnotations());
-  dispatch(createClassification(subject));
-};
-
 /*  Fetches a Zooniverse subject from Panoptes.
     - subjectId: OPTIONAL. ID of the subject, as a string. e.g.: "1234"
         If unspecified (undefined), fetches from list of queued subjects.
@@ -99,7 +99,7 @@ const fetchSubject = (subjectId = null) => {
           });
 
           //onSuccess(), prepare for a new subject.
-          prepareForNewSubject(dispatch, currentSubject);
+          dispatch(prepareForNewSubject(currentSubject));
         })
 
         .catch((err)=>{
@@ -133,7 +133,7 @@ const fetchSubject = (subjectId = null) => {
             });
 
             //onSuccess(), prepare for a new subject.
-            prepareForNewSubject(dispatch, currentSubject);
+            dispatch(prepareForNewSubject(currentSubject));
           })
           .catch((err) => {
             console.error('ducks/subject.js fetchSubject() error: ', err);
@@ -155,11 +155,28 @@ const fetchSubject = (subjectId = null) => {
         });
 
         //onSuccess(), prepare for a new subject.
-        prepareForNewSubject(dispatch, currentSubject);
+        dispatch(prepareForNewSubject(currentSubject));
       }
       
     }
   };
+};
+
+/*  Resets Subject to its initial values.
+ */
+const resetSubject = () => {
+  return (dispatch) => {
+    dispatch({ type: RESET_SUBJECT });
+  }
+};
+
+/*  Resets all the dependencies that rely on the Subject.
+ */
+const prepareForNewSubject = (subject) => {
+  return (dispatch) => {
+    dispatch(resetAnnotations());
+    dispatch(createClassification(subject));
+  }
 };
 
 const subjectError = () => {
@@ -215,6 +232,7 @@ const toggleFavorite = () => {
 export default subjectReducer;
 
 export {
+  resetSubject,
   fetchSubject,
   subjectError,
   toggleFavorite,

--- a/src/ducks/work-in-progress.js
+++ b/src/ducks/work-in-progress.js
@@ -1,0 +1,124 @@
+/*
+Save Progress
+-------------
+
+This library/duck provides mechanisms for users to save and resume their
+transcription work.
+
+Design:
+For Scribes of the Cairo Geniza, we're opting to go with the Local Storage
+method of saving/loading works in progress, instead of using Panoptes's built-in
+"save incomplete Classification" mechanism. This is due to our experience with
+Anti-Slavery Manuscripts, where network issues meant the Panoptes method - which
+was intended as a safety net - became another possible point of failure.
+
+Usage:
+```
+import { WorkInProgress } from './work-in-progress';
+
+class ReduxConnectedReactComponent {
+  ...
+  test() {
+    //Returns true/false if user has work in progress.
+    //DOES NOT use Redux's dispatch().
+    WorkInProgress.check(this.props.zooniverse_user);
+
+    //Deletes any work in progress
+    this.props.dispatch(WorkInProgress.clear());
+    
+    //Saves any work in progress
+    this.props.dispatch(WorkInProgress.clear());
+    
+    //Loads any work in progress
+    this.props.dispatch(WorkInProgress.clear());
+  }
+}
+
+```
+
+--------------------------------------------------------------------------------
+ */
+
+//import { fetchSavedSubject, prepareForNewSubject, setSubjectId } from './subject';
+//import { setAnnotations } from './annotations';
+
+const WORKFLOW_ID_KEY = 'workInProgress_workflowId';
+const SUBJECT_ID_KEY = 'workInProgress_subjectId';
+const ANNOTATIONS_KEY = 'workInProgress_annotations';
+const ANONYMOUS_USER_ID = 'anonymous';
+
+/*  Checks if the user has any work in progress saved.
+    Doesn't use Redux's dispatch() since this is a simple synchronous check.
+    I'm sorry for not following the pattern for the rest of the functions.
+ */
+const check = (user) => {
+  const userId = (user) ? user.id : ANONYMOUS_USER_ID;
+  const workflowId = localStorage.getItem(`${userId}.${WORKFLOW_ID_KEY}`);
+  const subjectId = localStorage.getItem(`${userId}.${SUBJECT_ID_KEY}`);
+  const annotations = localStorage.getItem(`${userId}.${ANNOTATIONS_KEY}`);
+
+  return !!workflowId && !!subjectId && !!annotations;
+}
+
+/*  Clears any work in progress the user has.
+    Needs to be called via Redux's dispatch().
+ */
+const clear = () => {
+  return (dispatch, getState) => {
+    const userId = (getState().login.user) ? getState().login.user.id : ANONYMOUS_USER_ID;
+    localStorage.removeItem(`${userId}.${SUBJECT_ID_KEY}`);
+    localStorage.removeItem(`${userId}.${ANNOTATIONS_KEY}`);
+  }
+};
+
+/*  Saves any work in progress the user has.
+    Needs to be called via Redux's dispatch().
+ */
+const save = () => {
+  return (dispatch, getState) => {
+    const workflowId = getState().workflow.id;
+    const subjectId = getState().subject.id;
+    const annotations = getState().annotations.annotations;
+
+    if (subjectId !== null) {      
+      const userId = (getState().login.user) ? getState().login.user.id : ANONYMOUS_USER_ID;
+      localStorage.setItem(`${userId}.${WORKFLOW_ID_KEY}`, workflowId);
+      localStorage.setItem(`${userId}.${SUBJECT_ID_KEY}`, subjectId);
+      localStorage.setItem(`${userId}.${ANNOTATIONS_KEY}`, JSON.stringify(annotations));
+    }
+  };
+};
+
+/*  Loads any work in progress the user has and TRIGGERS the necessary
+    Workflow-Subject-Classification lifecycle updates.
+    Needs to be called via Redux's dispatch().
+ */
+const load = () => {
+  return (dispatch, getState) => {
+    try {
+      const userId = (getState().login.user) ? getState().login.user.id : ANONYMOUS_USER_ID;
+      const workflowId = localStorage.getItem(`${userId}.${WORKFLOW_ID_KEY}`);
+      const subjectId = localStorage.getItem(`${userId}.${SUBJECT_ID_KEY}`);  //TODO: Check if a type conversion is required.
+      const annotations = JSON.parse(localStorage.getItem(`${userId}.${ANNOTATIONS_KEY}`));
+      
+      //dispatch(fetchSavedSubject(subjectId));
+      //dispatch(fetchSavedSubject(subjectId));
+      //dispatch(setSubjectId(subjectId));  //Required so that when prepareForNewSubject creates a Classification, subject ID isn't null. (fetchSavedSubject, above, is async, you see.)
+      //prepareForNewSubject(dispatch, null);
+      //dispatch(setAnnotations(annotations));  //Note: be sure to set Annotations AFTER prepareForNewSubject().
+    } catch (err) {
+      //TODO
+    }
+  };
+};
+
+const WorkInProgress = {
+  check,
+  save,
+  load,
+  clear,  
+};
+
+export {
+  WorkInProgress
+};

--- a/src/ducks/work-in-progress.js
+++ b/src/ducks/work-in-progress.js
@@ -39,6 +39,8 @@ class ReduxConnectedReactComponent {
 --------------------------------------------------------------------------------
  */
 
+import PropTypes from 'prop-types';
+
 import { fetchWorkflow } from './workflow';
 import { fetchSubject } from './subject';
 import { loadAnnotations } from './annotations';
@@ -50,10 +52,91 @@ import { loadAnnotations } from './annotations';
 // Constants and Action Types
 // --------------------------
 
+const SET_TIMESTAMP = 'work-in-progress/SET_TIMESTAMP';
+const CLEAR_TIMESTAMP = 'work-in-progress/CLEAR_TIMESTAMP';
+
 const WORKFLOW_ID_KEY = 'workInProgress_workflowId';
 const SUBJECT_ID_KEY = 'workInProgress_subjectId';
 const ANNOTATIONS_KEY = 'workInProgress_annotations';
 const ANONYMOUS_USER_ID = 'anonymous';
+
+//See ./reducer.js for the store name.
+const REDUX_STORE_NAME = 'workInProgress';
+
+/*
+--------------------------------------------------------------------------------
+ */
+
+// React-Redux Helper Objects
+// --------------------------
+
+/*  WORKINPROGRESS_INITIAL_STATE defines the default/starting values of the
+    Redux store. To use this in your Redux-connected React components, try...
+
+    Usage:
+      MyReactComponent.defaultProps = {
+        ...WORKINPROGRESS_INITIAL_STATE,
+        otherProp: 'default value'
+      };
+ */
+const WORKINPROGRESS_INITIAL_STATE = {
+  wipTimestamp: null,  //'Date' object indicating the last time a save was made.
+                       //null if there's no save.
+};
+
+/*  WORKINPROGRESS_PROPTYPES is used to define the property types of the data,
+    and only matters to Redux-connected React components.
+
+    Usage:
+      MyReactComponent.propTypes = {
+        ...WORKINPROGRESS_PROPTYPES,
+        otherProp: PropTypes.string,
+      };
+ */
+const WORKINPROGRESS_PROPTYPES = {
+  wipTimestamp: PropTypes.object,
+};
+
+/*  Used as a convenience feature in mapStateToProps() functions in
+    Redux-connected React components.
+
+    Usage:
+      mapStateToProps = (state) => {
+        return {
+          ...getWorkInProgressStateValues(state),
+          someOtherValue: state.someOtherStore.someOtherValue
+        }
+      }
+ */
+const getWorkInProgressStateValues = (state) => {
+  return {
+    wipTimestamp: state[REDUX_STORE_NAME].wipTimestamp,
+  };
+};
+
+/*
+--------------------------------------------------------------------------------
+ */
+
+// Redux Reducer
+// -------------
+
+const wipReducer = (state = WORKINPROGRESS_INITIAL_STATE, action) => {
+  switch (action.type) {
+    case SET_TIMESTAMP:
+      return Object.assign({}, state, {
+        wipTimestamp: action.timestamp,
+      });
+    
+    case CLEAR_TIMESTAMP:
+      return Object.assign({}, state, {
+        wipTimestamp: null,
+      });
+
+    default:
+      return state;
+  };
+};
 
 /*
 --------------------------------------------------------------------------------
@@ -85,6 +168,8 @@ const clear = () => {
     localStorage.removeItem(`${userId}.${SUBJECT_ID_KEY}`);
     localStorage.removeItem(`${userId}.${ANNOTATIONS_KEY}`);
     
+    //Store update
+    dispatch({ type: CLEAR_TIMESTAMP });
     console.log('WorkInProgress.clear()');
   }
 };
@@ -109,6 +194,8 @@ const save = () => {
     localStorage.setItem(`${userId}.${SUBJECT_ID_KEY}`, subjectId);
     localStorage.setItem(`${userId}.${ANNOTATIONS_KEY}`, JSON.stringify(annotations));
     
+    //Store update
+    dispatch({ type: SET_TIMESTAMP, timestamp: new Date(Date.now()) });
     console.log('WorkInProgress.save() success');
   };
 };
@@ -171,6 +258,11 @@ const WorkInProgress = {
 // Exports
 // -------
 
+export default wipReducer;
+
 export {
-  WorkInProgress
+  WorkInProgress,
+  WORKINPROGRESS_INITIAL_STATE,
+  WORKINPROGRESS_PROPTYPES,
+  getWorkInProgressStateValues,
 };

--- a/src/ducks/work-in-progress.js
+++ b/src/ducks/work-in-progress.js
@@ -93,8 +93,10 @@ const save = () => {
     const workflowId = getState().workflow.id;
     const subjectId = getState().subject.id;
     const annotations = getState().annotations.annotations;
+    
+    console.log('!'.repeat(100), workflowId, subjectId, annotations);
 
-    if (subjectId !== null) {      
+    if (workflowId && subjectId) {      
       const userId = (getState().login.user) ? getState().login.user.id : ANONYMOUS_USER_ID;
       localStorage.setItem(`${userId}.${WORKFLOW_ID_KEY}`, workflowId);
       localStorage.setItem(`${userId}.${SUBJECT_ID_KEY}`, subjectId);

--- a/src/ducks/work-in-progress.js
+++ b/src/ducks/work-in-progress.js
@@ -39,7 +39,8 @@ class ReduxConnectedReactComponent {
 --------------------------------------------------------------------------------
  */
 
-//import { fetchSavedSubject, prepareForNewSubject, setSubjectId } from './subject';
+import { fetchWorkflow } from './workflow';
+import { fetchSubject } from './subject';
 //import { setAnnotations } from './annotations';
 
 /*
@@ -94,9 +95,7 @@ const save = () => {
     const subjectId = getState().subject.id;
     const annotations = getState().annotations.annotations;
     
-    console.log('!'.repeat(100), workflowId, subjectId, annotations);
-
-    if (workflowId && subjectId) {      
+    if (workflowId && subjectId) {
       const userId = (getState().login.user) ? getState().login.user.id : ANONYMOUS_USER_ID;
       localStorage.setItem(`${userId}.${WORKFLOW_ID_KEY}`, workflowId);
       localStorage.setItem(`${userId}.${SUBJECT_ID_KEY}`, subjectId);
@@ -116,6 +115,16 @@ const load = () => {
       const workflowId = localStorage.getItem(`${userId}.${WORKFLOW_ID_KEY}`);
       const subjectId = localStorage.getItem(`${userId}.${SUBJECT_ID_KEY}`);  //TODO: Check if a type conversion is required.
       const annotations = JSON.parse(localStorage.getItem(`${userId}.${ANNOTATIONS_KEY}`));
+      
+      Promise.all([
+        dispatch(fetchWorkflow(workflowId)),
+      ]).then(() => {
+        Promise.all([
+          dispatch(fetchSubject(subjectId)),
+        ]).then(() => {
+          console.log('+'.repeat(100), annotations);
+        });
+      });
       
       //dispatch(fetchSavedSubject(subjectId));
       //dispatch(fetchSavedSubject(subjectId));

--- a/src/ducks/work-in-progress.js
+++ b/src/ducks/work-in-progress.js
@@ -189,7 +189,7 @@ const save = () => {
       console.error('WorkInProgress.save() error: nothing to save.');
       return;
     }
-      
+
     localStorage.setItem(`${userId}.${WORKFLOW_ID_KEY}`, workflowId);
     localStorage.setItem(`${userId}.${SUBJECT_ID_KEY}`, subjectId);
     localStorage.setItem(`${userId}.${ANNOTATIONS_KEY}`, JSON.stringify(annotations));

--- a/src/ducks/work-in-progress.js
+++ b/src/ducks/work-in-progress.js
@@ -42,10 +42,24 @@ class ReduxConnectedReactComponent {
 //import { fetchSavedSubject, prepareForNewSubject, setSubjectId } from './subject';
 //import { setAnnotations } from './annotations';
 
+/*
+--------------------------------------------------------------------------------
+ */
+
+// Constants and Action Types
+// --------------------------
+
 const WORKFLOW_ID_KEY = 'workInProgress_workflowId';
 const SUBJECT_ID_KEY = 'workInProgress_subjectId';
 const ANNOTATIONS_KEY = 'workInProgress_annotations';
 const ANONYMOUS_USER_ID = 'anonymous';
+
+/*
+--------------------------------------------------------------------------------
+ */
+
+// Action Creators
+// ---------------
 
 /*  Checks if the user has any work in progress saved.
     Doesn't use Redux's dispatch() since this is a simple synchronous check.
@@ -112,12 +126,29 @@ const load = () => {
   };
 };
 
+/*
+--------------------------------------------------------------------------------
+ */
+
+// Function Library
+// ----------------
+
+/*  Actions are packaged into a single "library object" for ease of importing
+    between components.
+ */
 const WorkInProgress = {
   check,
   save,
   load,
   clear,  
 };
+
+/*
+--------------------------------------------------------------------------------
+ */
+
+// Exports
+// -------
 
 export {
   WorkInProgress

--- a/src/ducks/work-in-progress.js
+++ b/src/ducks/work-in-progress.js
@@ -116,14 +116,11 @@ const load = () => {
       const subjectId = localStorage.getItem(`${userId}.${SUBJECT_ID_KEY}`);  //TODO: Check if a type conversion is required.
       const annotations = JSON.parse(localStorage.getItem(`${userId}.${ANNOTATIONS_KEY}`));
       
-      Promise.all([
-        dispatch(fetchWorkflow(workflowId)),
-      ]).then(() => {
-        Promise.all([
-          dispatch(fetchSubject(subjectId)),
-        ]).then(() => {
-          console.log('+'.repeat(100), annotations);
-        });
+      dispatch(fetchWorkflow(workflowId)).then(() => {
+        console.log('+'.repeat(100), 'aaa');
+        return dispatch(fetchSubject(subjectId));                                    
+      }).then(() => {
+        console.log('+'.repeat(100), 'bbb');
       });
       
       //dispatch(fetchSavedSubject(subjectId));

--- a/src/ducks/work-in-progress.js
+++ b/src/ducks/work-in-progress.js
@@ -219,14 +219,18 @@ const load = () => {
       }
       
       //First, load the Workflow, then the Subject, then the Annotations.
-      //Finally, clear all saved WIP data.
       dispatch(fetchWorkflow(workflowId)).then(() => {
         return dispatch(fetchSubject(subjectId));
       }).then(() => {
         return dispatch(loadAnnotations(annotations));
       }).then(() => {
         console.log('WorkInProgress.load() success');
-        return dispatch(clear());
+        
+        //If we want to remove all saved progress when a user successfully
+        //loads their data, enable this following line:
+        //  return dispatch(clear());
+        
+        return null;
       });
     } catch (err) {
       console.error('WorkInProgress.load() error: ', err);

--- a/src/ducks/work-in-progress.js
+++ b/src/ducks/work-in-progress.js
@@ -41,7 +41,7 @@ class ReduxConnectedReactComponent {
 
 import { fetchWorkflow } from './workflow';
 import { fetchSubject } from './subject';
-//import { setAnnotations } from './annotations';
+import { loadAnnotations } from './annotations';
 
 /*
 --------------------------------------------------------------------------------
@@ -117,10 +117,11 @@ const load = () => {
       const annotations = JSON.parse(localStorage.getItem(`${userId}.${ANNOTATIONS_KEY}`));
       
       dispatch(fetchWorkflow(workflowId)).then(() => {
-        console.log('+'.repeat(100), 'aaa');
-        return dispatch(fetchSubject(subjectId));                                    
+        return dispatch(fetchSubject(subjectId));
       }).then(() => {
-        console.log('+'.repeat(100), 'bbb');
+        return dispatch(loadAnnotations(annotations));
+      }).then(() => {
+        return dispatch(clear());
       });
       
       //dispatch(fetchSavedSubject(subjectId));

--- a/src/ducks/workflow.js
+++ b/src/ducks/workflow.js
@@ -1,6 +1,10 @@
 import apiClient from 'panoptes-client/lib/api-client';
 import { config } from '../config';
 
+import { resetSubject } from './subject';
+import { resetAnnotations } from './annotations';
+import { createClassification } from './classification';
+
 // Action Types
 const FETCH_WORKFLOW = 'FETCH_WORKFLOW';
 const FETCH_WORKFLOW_SUCCESS = 'FETCH_WORKFLOW_SUCCESS';
@@ -57,11 +61,24 @@ const fetchWorkflow = (workflowId = config.workflowId) => {
           type: FETCH_WORKFLOW_SUCCESS,
           data: workflow
         });
+
+        //onSuccess(), prepare for a new workflow.
+        dispatch(prepareForNewWorkflow());
       })
       .catch(() => {
         dispatch({ type: FETCH_WORKFLOW_ERROR });
       });
   };
+};
+
+/*  Resets all the dependencies that rely on the Workflow.
+ */
+const prepareForNewWorkflow = () => {
+  return (dispatch) => {
+    dispatch(resetSubject());
+    dispatch(resetAnnotations());
+    dispatch(createClassification(subject));
+  }
 };
 
 export default workflowReducer;

--- a/src/ducks/workflow.js
+++ b/src/ducks/workflow.js
@@ -44,14 +44,14 @@ const workflowReducer = (state = initialState, action) => {
   }
 };
 
-const fetchWorkflow = (id = config.workflowId) => {
+const fetchWorkflow = (workflowId = config.workflowId) => {
   return (dispatch) => {
     dispatch({
       type: FETCH_WORKFLOW,
-      id
+      id: workflowId,
     });
 
-    apiClient.type('workflows').get(id)
+    apiClient.type('workflows').get(workflowId)
       .then((workflow) => {
         dispatch({
           type: FETCH_WORKFLOW_SUCCESS,

--- a/src/ducks/workflow.js
+++ b/src/ducks/workflow.js
@@ -51,7 +51,7 @@ const fetchWorkflow = (workflowId = config.workflowId) => {
       id: workflowId,
     });
 
-    apiClient.type('workflows').get(workflowId)
+    return apiClient.type('workflows').get(workflowId)
       .then((workflow) => {
         dispatch({
           type: FETCH_WORKFLOW_SUCCESS,

--- a/src/locales/ar.js
+++ b/src/locales/ar.js
@@ -32,6 +32,12 @@ export default {
     finished: 'تم الانتهاء',
     lastSave: 'Last save'
   },
+  workInProgress: {
+    header: 'Resume Work In Progress?',
+    message: 'We detected that you have some work in progress saved. You can continue your saved work, or start with a new page.',
+    startNewWork: 'New Page',
+    resumeWorkInProgress: 'Resume Work',
+  },
   transcribeBox: {
     title: 'نسخ',
     instructions: '.تتم قراءة اللغة العبرية من اليمين إلى اليسار، فبدأ على اليمين',

--- a/src/locales/ar.js
+++ b/src/locales/ar.js
@@ -29,7 +29,8 @@ export default {
     showTutorial: 'إظهار الدرس التعليمي ',
     hideTutorial: 'إخفاء الدرس التعليمي',
     saveProgress: 'حفظ التقدم',
-    finished: 'تم الانتهاء'
+    finished: 'تم الانتهاء',
+    lastSave: 'Last save'
   },
   transcribeBox: {
     title: 'نسخ',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -32,6 +32,12 @@ export default {
     finished: 'Finished',
     lastSave: 'Last save'
   },
+  workInProgress: {
+    header: 'Resume Work In Progress?',
+    message: 'We detected that you have some work in progress saved. You can continue your saved work, or start with a new page.',
+    startNewWork: 'New Page',
+    resumeWorkInProgress: 'Resume Work',
+  },
   transcribeBox: {
     title: 'Transcribe',
     instructions: 'The Hebrew language reads from right to left, so start on the right side.',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -29,7 +29,8 @@ export default {
     showTutorial: 'Show Tutorial',
     hideTutorial: 'Hide Tutorial',
     saveProgress: 'Save Progress',
-    finished: 'Finished'
+    finished: 'Finished',
+    lastSave: 'Last save'
   },
   transcribeBox: {
     title: 'Transcribe',

--- a/src/locales/he.js
+++ b/src/locales/he.js
@@ -29,7 +29,8 @@ export default {
     showTutorial: 'הצג מדריך לעבודה באתר',
     hideTutorial: 'סגור הדרכה',
     saveProgress: 'שמור התקדמות',
-    finished: 'סיום'
+    finished: 'סיום',
+    lastSave: 'Last save'
   },
   transcribeBox: {
     title: 'תעתוק',

--- a/src/locales/he.js
+++ b/src/locales/he.js
@@ -32,6 +32,12 @@ export default {
     finished: 'סיום',
     lastSave: 'Last save'
   },
+  workInProgress: {
+    header: 'Resume Work In Progress?',
+    message: 'We detected that you have some work in progress saved. You can continue your saved work, or start with a new page.',
+    startNewWork: 'New Page',
+    resumeWorkInProgress: 'Resume Work',
+  },
   transcribeBox: {
     title: 'תעתוק',
     instructions: '.הקלד את הטקסט שלפניך',

--- a/src/styles/components/control-panel.styl
+++ b/src/styles/components/control-panel.styl
@@ -148,5 +148,4 @@
       transform-origin: 2em 1em
 
   .workinprogress-timestamp
-    font-size: 0.8em
-    text-align: center
+    line-height: 1.2rem

--- a/src/styles/components/control-panel.styl
+++ b/src/styles/components/control-panel.styl
@@ -146,3 +146,7 @@
 
     h2
       transform-origin: 2em 1em
+
+  .workinprogress-timestamp
+    font-size: 0.8em
+    text-align: center

--- a/src/styles/components/control-panel.styl
+++ b/src/styles/components/control-panel.styl
@@ -4,7 +4,7 @@
   -webkit-box-shadow: 0px 10px 24px -10px rgba(180,180,180,1)
   -moz-box-shadow: 0px 10px 24px -10px rgba(180,180,180,1)
   color: $plum
-  height: 36rem
+  min-height: 36rem
   position: absolute
   top: 12%
   width: 17rem

--- a/src/styles/components/work-in-progress-popup.styl
+++ b/src/styles/components/work-in-progress-popup.styl
@@ -1,0 +1,41 @@
+.work-in-progress-popup-container
+  background: rgba(255, 255, 255, 0.5)
+  cursor: default
+  display: flex
+  height: 100vh
+  left: 0
+  position: fixed
+  top: 0
+  width: 100vw
+  z-index: 1000
+
+.work-in-progress-popup
+  background-color: $bisque
+  margin: auto
+  padding: 2em
+  width: 32rem
+  min-height: 16rem
+  box-shadow: 0px 10px 24px -10px rgba(180,180,180,1)
+  -webkit-box-shadow: 0px 10px 24px -10px rgba(180,180,180,1)
+  -moz-box-shadow: 0px 10px 24px -10px rgba(180,180,180,1)
+  display: flex
+  flex-direction: column
+  justify-content: center
+
+  button
+    width: 10.5rem
+  
+  &__header
+    font-size: 1.1em
+    font-weight: bold
+    display: block
+    padding: 0.5em 0
+
+  > div
+    flex: 0 0 auto
+
+  > div:last-child
+    margin-top: 1rem
+    display: flex
+    justify-content: space-around
+

--- a/src/styles/components/work-in-progress-popup.styl
+++ b/src/styles/components/work-in-progress-popup.styl
@@ -12,8 +12,8 @@
 .work-in-progress-popup
   background-color: $bisque
   margin: auto
-  padding: 2em
-  width: 32rem
+  padding: 0em
+  width: 33.5rem
   min-height: 16rem
   box-shadow: 0px 10px 24px -10px rgba(180,180,180,1)
   -webkit-box-shadow: 0px 10px 24px -10px rgba(180,180,180,1)
@@ -21,21 +21,26 @@
   display: flex
   flex-direction: column
   justify-content: center
-
-  button
-    width: 10.5rem
   
-  &__header
-    font-size: 1.1em
-    font-weight: bold
-    display: block
-    padding: 0.5em 0
-
-  > div
+  .pseudo-drag-bar
+    background-color: $sand
+    border: 0
+    width: 100%
+    height: 0.5rem
+    margin: 0
     flex: 0 0 auto
 
-  > div:last-child
-    margin-top: 1rem
+  &__content
+    padding: 1.5rem
+    flex: 1 1 auto
+    
+  &__message
+    @extend .body-font
+  
+  &__controls
+    margin: 2rem 0 0 0
     display: flex
-    justify-content: space-around
+    justify-content: space-between
 
+    button
+      width: 14.5rem


### PR DESCRIPTION
## PR Overview
This PR adds the ability for users to save/resume their work in progress, by using the Save Progress button on the Classifier page.
- A `WorkInProgress` duck/function library has been added.
  - For future-proofing I'm reorganising how we code our ducks, starting with WorkInProgress.
- Prerequisite (in this PR): the Workflow and/or Subject duck will need to be updated to better follow a lifecycle Project-Workflow-Subject-Classification dependency lifecycle.
  - This is because when a save project is loaded, it needs to pick a specific workflow, then pick a specific subject, in that order - this may short-circuit the way we currently baked workflow-subject fetch assumptions, if we're not careful.

### Intended design
- When a user visits the Classifier, check if the user has a saved work in progress.
  - If nothing, proceed as normal.
  - If something, prompt user to "start anew" or "continue work in progress" 
    - if start anew, clear all work in progress and load Classifier as normal.
    - if continue, LOAD SAVED WORKFLOW, then LOAD SAVED SUBJECT (in that order!) then create a new empty Classification (with the correct Workflow ID and Subject ID), then load saved annotations.
- When a user submits a Classification SUCCESSFULLY, clear all work in progress before fetching the next Subject.

### Status
The WorkInProgress duck is still a work in progress, and work is progressing.