### PR TITLE
Frame Switching - Allow Switching Between Front Page and Reverse Page

### DIFF
--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -7,6 +7,7 @@ import { getTranslate, getActiveLanguage } from 'react-localize-redux';
 
 import { fetchGuide } from '../ducks/field-guide';
 import { toggleDialog, togglePopup } from '../ducks/dialog';
+import { changeFrame } from '../ducks/subject-viewer';
 import {
   WorkInProgress, WORKINPROGRESS_INITIAL_STATE, WORKINPROGRESS_PROPTYPES,
   getWorkInProgressStateValues
@@ -208,7 +209,10 @@ class ControlPanel extends React.Component {
           <hr className="white-line" />
 
           <div>
-            <button className="button">{this.props.translate('infoBox.transcribeReverse')}</button>
+            {(this.props.frame === 0)
+              ? <button className="button" onClick={()=>{this.props.dispatch(changeFrame(1))}}>{this.props.translate('infoBox.transcribeReverse')}</button>
+              : <button className="button" onClick={()=>{this.props.dispatch(changeFrame(0))}}>{this.props.translate('infoBox.transcribeFront')}</button>
+            }
             {this.props.user && (  //Show the Save Progress button to logged-in users only.
               <button className="button" onClick={()=>{this.props.dispatch(WorkInProgress.save())}}>
                 {this.props.translate('infoBox.saveProgress')}
@@ -276,6 +280,7 @@ ControlPanel.defaultProps = {
   dialog: null,
   dialogComponent: null,
   dispatch: () => {},
+  frame: 0,
   guide: null,
   icons: null,
   preferences: null,
@@ -293,6 +298,7 @@ const mapStateToProps = (state) => {
     currentLanguage: getActiveLanguage(state.locale).code,
     dialog: state.dialog.data,
     dialogComponent: state.dialog.component,
+    frame: state.subjectViewer.frame,
     guide: state.fieldGuide.guide,
     icons: state.fieldGuide.icons,
     preferences: state.project.userPreferences,

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -209,10 +209,11 @@ class ControlPanel extends React.Component {
           <hr className="white-line" />
 
           <div>
-            {(this.props.frame === 0)
-              ? <button className="button" onClick={()=>{this.props.dispatch(changeFrame(1))}}>{this.props.translate('infoBox.transcribeReverse')}</button>
-              : <button className="button" onClick={()=>{this.props.dispatch(changeFrame(0))}}>{this.props.translate('infoBox.transcribeFront')}</button>
-            }
+            {(!(this.props.currentSubject && this.props.currentSubject.locations && this.props.currentSubject.locations.length >= 2)) ? null : (
+              (this.props.frame === 0)
+                ? <button className="button" onClick={()=>{this.props.dispatch(changeFrame(1))}}>{this.props.translate('infoBox.transcribeReverse')}</button>
+                : <button className="button" onClick={()=>{this.props.dispatch(changeFrame(0))}}>{this.props.translate('infoBox.transcribeFront')}</button>
+            )}
             {this.props.user && (  //Show the Save Progress button to logged-in users only.
               <button className="button" onClick={()=>{this.props.dispatch(WorkInProgress.save())}}>
                 {this.props.translate('infoBox.saveProgress')}
@@ -252,6 +253,7 @@ class ControlPanel extends React.Component {
 }
 
 ControlPanel.propTypes = {
+  currentSubject: PropTypes.object,
   dialog: PropTypes.node,
   dialogComponent: PropTypes.string,
   dispatch: PropTypes.func,
@@ -277,6 +279,7 @@ ControlPanel.propTypes = {
 };
 
 ControlPanel.defaultProps = {
+  currentSubject: null,
   dialog: null,
   dialogComponent: null,
   dispatch: () => {},
@@ -296,6 +299,7 @@ ControlPanel.defaultProps = {
 const mapStateToProps = (state) => {
   return {
     currentLanguage: getActiveLanguage(state.locale).code,
+    currentSubject: state.subject.currentSubject,
     dialog: state.dialog.data,
     dialogComponent: state.dialog.component,
     frame: state.subjectViewer.frame,

--- a/src/ducks/subject-viewer.js
+++ b/src/ducks/subject-viewer.js
@@ -28,6 +28,7 @@ const TOGGLE_CONTRAST = 'TOGGLE_CONTRAST';
 const SET_VIEWER_STATE = 'SET_VIEWER_STATE';
 const UPDATE_IMAGE_SIZE = 'UPDATE_IMAGE_SIZE';
 const UPDATE_VIEWER_SIZE = 'UPDATE_VIEWER_SIZE';
+const CHANGE_FRAME = 'CHANGE_FRAME';
 
 const subjectViewerReducer = (state = initialState, action) => {
   switch (action.type) {
@@ -117,6 +118,11 @@ const subjectViewerReducer = (state = initialState, action) => {
       });
     }
 
+    case CHANGE_FRAME:
+      return Object.assign({}, state, {
+        frame: action.frame
+      });
+
     default: {
       return state;
     }
@@ -195,9 +201,19 @@ const toggleContrast = () => {
   };
 };
 
+const changeFrame = (frame) => {
+  return (dispatch) => {
+    dispatch({
+      type: CHANGE_FRAME,
+      frame
+    });
+  }
+};
+
 export default subjectViewerReducer;
 
 export {
+  changeFrame,
   resetView,
   setRotation,
   setScaling,

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -3,6 +3,7 @@ import { config } from '../config';
 
 import { resetAnnotations } from './annotations';
 import { createClassification } from './classification';
+import { changeFrame } from './subject-viewer';
 
 // Action Types
 const RESET_SUBJECT = 'FETCH_SUBJECT';
@@ -176,6 +177,7 @@ const prepareForNewSubject = (subject) => {
   return (dispatch) => {
     dispatch(resetAnnotations());
     dispatch(createClassification(subject));
+    dispatch(changeFrame(0));
   }
 };
 


### PR DESCRIPTION
## PR Overview
This PR adds functionality to the "Transcribe Page Reverse" button on the Classifier Page's toolbar. As it says on the tin, it flips the page shows the other side, allowing the users a whole new image to annotate. 
- This assumes that Subject in Scribes of the Cairo Geniza has EXACTLY two images, corresponding to the front page and the back page. (Each image = a "frame", in code terms)
- As a result, each annotation/transcription submitted in the Classification will have a `frame` value, which indicates which page the annotation/transcription was made on.
- We're using a 0-index, so frame 0 is for first front page, and frame 1 is for the reverse page.

### Dev Notes

Surprisingly, the groundwork for frame switching is already well baked into the project code, and not much else is needed. Classifications _and_ annotations already respect the `frame` value, and the Subject Viewer seems to render the correct page nicely (with annotations for the front page being separate from annotations for the reverse page) - this PR mostly seems to involve activating the "switchThePagePlease()" function in the "page-switching" button.

Some testing still needs to be done though, as I'm seeing blank images for the reverse pages. This _might_ be due to the Subjects on staging not having a reverse image.

### Status
WIP 