### PR TITLE
Fix Subject Queue

### DIFF
--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -149,7 +149,7 @@ const fetchSubject = (subjectId = null) => {
         dispatch({
           currentSubject,
           id: currentSubject.id,
-          queue: getState().subject.queue,
+          queue: updatedQueue,
           type: FETCH_SUBJECT_SUCCESS,
           favorite: currentSubject.favorite || false
         });


### PR DESCRIPTION
## PR Overview
This PR fixes an issue I accidentally introduced in commit https://github.com/zooniverse/scribes-of-the-cairo-geniza/commit/f1308d327cffa7663ceb3e492334e22068e68152 . Without this PR, once we cannot _progress past the second item_ in a Subject queue.

This was due to a branch of `fetchSubject()` where an updated copy of the queue is created via `const updatedQueue = getState().subject.queue.slice()`, but instead of updating the store with the _updated, shorter_ queue, I updated it with the _original_ queue instead. Whoops!

### Status
Merging this fix ASAP.