### PR TITLE
Setup Production

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -34,8 +34,8 @@ const baseConfig = {
     hebrewKeyword: '3156'
   },
   production: {
-    panoptesAppId: '',
-    host: 'https://www.zooniverse.org/',
+    panoptesAppId: '68db6a8181e26483a9f82b66b511ca849ef170b10c0e997bdcc277003d779ac6',
+    host: 'https://www.scribesofthecairogeniza.org/',
     projectId: '5042',
     projectSlug: 'judaicadh/scribes-of-the-cairo-geniza',
     easyArabic: '6654',


### PR DESCRIPTION
## PR Overview
This PR prepares Scribes of the Cairo Geniza for deployment to production at https://www.scribesofthecairogeniza.org.

- In particular, this PR adds a Zooniverse App ID so **users can sign in to the website**
- External dependency: the website needs to be added to the Zooniverse whitelist, so _users can sign out._ This is being taken care of by myself, in a separate repo.
- External dependency: the four production workflows (Easy Hebrew, Advanced Hebrew, Easy Arabic, Advanced Arabic) need a back-end pipeline so they can be fed subjects; this is being coordinated by @wgranger 
  - Note that a temporary "placeholder Subject Set" will need to be in place while that pipeline is being built.
- The Zooniverse project (`judaicadh/scribes-of-the-cairo-geniza`), web server (`https://www.scribesofthecairogeniza.org/`), and the corresponding `deploy-production` npm script have already been set up before.

### Status
I'm self-merging this and deploying it, with the latest changes, to `production`.

The two external dependencies above need to be followed up on ASAP, otherwise our team won't be able to test `scribesofthecairogeniza.org` properly.