### PR TITLE
Fix "Resume Progress"

### DIFF
--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -46,9 +46,9 @@ class ControlPanel extends React.Component {
   }
 
   componentDidMount() {
-    //Check if the user has any work in progress.
+    //If there's no Subject loaded, check if the user has any work in progress.
     //componentDidMount() checks when the user accesses the Classifier page from another page, e.g. the Home page.
-    if (this.props.user && WorkInProgress.check(this.props.user)) {
+    if (!this.props.currentSubject && this.props.user && WorkInProgress.check(this.props.user)) {
       this.props.dispatch(togglePopup(<WorkInProgressPopup />));
     }
   }
@@ -62,9 +62,10 @@ class ControlPanel extends React.Component {
       });
     }
 
-    //Check if the user has any work in progress.
+    //If there's no Subject loaded, check if the user has any work in progress.
     //componentWillReceiveProps() checks when the user accesses the Classifier page directly.
-    if (this.props.user !== next.user && next.user && WorkInProgress.check(next.user)) {
+    if (!this.props.currentSubject && !next.currentSubject &&
+        this.props.user !== next.user && next.user && WorkInProgress.check(next.user)) {
       this.props.dispatch(togglePopup(<WorkInProgressPopup />));
     }
 

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -16,6 +16,7 @@ import HomeStatistics from './HomeStatistics';
 import FlippedImg from './styled/FlippedImg';
 import { config } from '../config';
 import { fetchWorkflow } from '../ducks/workflow';
+import { fetchSubject } from '../ducks/subject';
 
 import AboutGenizaAr from './about/about-geniza-ar';
 import AboutGenizaEn from './about/about-geniza-en';
@@ -23,7 +24,9 @@ import AboutGenizaHe from './about/about-geniza-he';
 
 const Home = ({ currentLanguage, dispatch, history, rtl, translate }) => {
   const selectWorkflow = (workflow) => {
-    dispatch(fetchWorkflow(workflow));
+    dispatch(fetchWorkflow(workflow)).then(()=>{
+      return dispatch(fetchSubject());
+    });
     history.push('/classify');
     window.scrollTo(0, 0);
   };

--- a/src/components/WorkInProgressPopup.jsx
+++ b/src/components/WorkInProgressPopup.jsx
@@ -27,6 +27,12 @@ class WorkInProgressPopup extends React.Component {
   startNewWork() {
     this.props.dispatch(WorkInProgress.clear());
     this.closePopup();
+    
+    //HACK  //TODO
+    //Due to the new workflow selection feature, we need to trigger a series of
+    //refreshes to allow the Classifier page to show the WorkflowDropdown
+    //module. This requires a more elegant solution.
+    window.location.reload();
   }
 
   render() {

--- a/src/components/WorkflowDropdown.jsx
+++ b/src/components/WorkflowDropdown.jsx
@@ -7,7 +7,7 @@ import { fetchWorkflow, toggleSelection } from '../ducks/workflow';
 import { fetchSubject } from '../ducks/subject';
 import { config } from '../config';
 
-const WorkflowDropdown = ({ className, dispatch, history, translate }) => {
+const WorkflowDropdown = ({ className, dispatch, history, translate, workflow, activeAnnotationExists }) => {
   const selectWorkflow = (workflow) => {
     dispatch(fetchWorkflow(workflow)).then(()=>{
       return dispatch(fetchSubject());
@@ -16,23 +16,40 @@ const WorkflowDropdown = ({ className, dispatch, history, translate }) => {
     history.push('/classify');
     window.scrollTo(0, 0);
   };
+  
+  const continueActiveAnnotation = () => {
+    dispatch(toggleSelection(false));
+    history.push('/classify');
+    window.scrollTo(0, 0);
+  };
+  
   const c = config;
   const classifyPath = `${c.host}projects/${c.projectSlug}/classify?workflow=`;
 
   return (
     <div className={`selection-container ${className}`}>
+      {(!activeAnnotationExists) ? null :(
+        <div>
+          <button
+            className="tertiary-label"
+            onClick={continueActiveAnnotation}
+          >
+            {translate('workflowSelection.continue')}
+          </button>
+        </div>
+      )}
       <div>
         <a
           className="tertiary-label"
           href={`${classifyPath}${c.phaseOne}`}
           target="_blank"
         >
-          Phase One: Classify Fragments <i className="fa fa-external-link" />
+          {translate('workflowSelection.phaseOne')} <i className="fa fa-external-link" />
         </a>
       </div>
       <div>
-        <span className="h1-font">Hebrew</span>
-        <span className="primary-label">Phase Two: Full Text Transcription</span>
+        <span className="h1-font">{translate('general.hebrew')}</span>
+        <span className="primary-label">{translate('workflowSelection.phaseTwo')}</span>
         <button
           className="tertiary-label"
           onClick={selectWorkflow.bind(null, c.easyHebrew)}
@@ -47,11 +64,11 @@ const WorkflowDropdown = ({ className, dispatch, history, translate }) => {
           >
             {translate('transcribeHebrew.challenging')}
           </button>
-          <span>Coming Soon!</span>
+          <span>{translate('general.comingSoon')}</span>
         </div>
 
         <div>
-          <span className="primary-label">Keyword Search</span>
+          <span className="primary-label">{translate('workflowSelection.keywordSearch')}</span>
           <a
             className="tertiary-label"
             href={`${classifyPath}${c.hebrewKeyword}`}
@@ -62,8 +79,8 @@ const WorkflowDropdown = ({ className, dispatch, history, translate }) => {
         </div>
       </div>
       <div>
-        <span className="h1-font">Arabic</span>
-        <span className="primary-label">Phase Two: Full Text Transcription</span>
+        <span className="h1-font">{translate('general.arabic')}</span>
+        <span className="primary-label">{translate('workflowSelection.phaseTwo')}</span>
         <button
           className="tertiary-label"
           onClick={selectWorkflow.bind(null, c.easyArabic)}
@@ -78,11 +95,11 @@ const WorkflowDropdown = ({ className, dispatch, history, translate }) => {
           >
             {translate('transcribeArabic.challenging')}
           </button>
-          <span>Coming Soon!</span>
+          <span>{translate('general.comingSoon')}</span>
         </div>
 
         <div>
-          <span className="primary-label">Keyword Search</span>
+          <span className="primary-label">{translate('workflowSelection.keywordSearch')}</span>
           <a
             className="tertiary-label"
             href={`${classifyPath}${c.arabicKeyword}`}
@@ -97,15 +114,27 @@ const WorkflowDropdown = ({ className, dispatch, history, translate }) => {
 };
 
 WorkflowDropdown.propTypes = {
+  activeAnnotationExists: PropTypes.bool,
   className: PropTypes.string,
   dispatch: PropTypes.func.isRequired,
   history: PropTypes.shape({
     push: PropTypes.func
   }).isRequired,
-  translate: PropTypes.func.isRequired
+  translate: PropTypes.func.isRequired,
+};
+
+WorkflowDropdown.defaultProps = {
+  activeAnnotationExists: false,
+  className: '',
+  dispatch: () => {},
+  history: {
+    push: () => {}
+  },
+  translate: () => {},
 };
 
 const mapStateToProps = state => ({
+  activeAnnotationExists: !!state.workflow.data && !!state.subject.currentSubject,
   currentLanguage: getActiveLanguage(state.locale).code,
   translate: getTranslate(state.locale)
 });

--- a/src/components/WorkflowDropdown.jsx
+++ b/src/components/WorkflowDropdown.jsx
@@ -4,11 +4,14 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { getTranslate, getActiveLanguage } from 'react-localize-redux';
 import { fetchWorkflow, toggleSelection } from '../ducks/workflow';
+import { fetchSubject } from '../ducks/subject';
 import { config } from '../config';
 
 const WorkflowDropdown = ({ className, dispatch, history, translate }) => {
   const selectWorkflow = (workflow) => {
-    dispatch(fetchWorkflow(workflow));
+    dispatch(fetchWorkflow(workflow)).then(()=>{
+      return dispatch(fetchSubject());
+    });
     dispatch(toggleSelection(false));
     history.push('/classify');
     window.scrollTo(0, 0);

--- a/src/components/WorkflowDropdown.jsx
+++ b/src/components/WorkflowDropdown.jsx
@@ -5,6 +5,7 @@ import { withRouter } from 'react-router-dom';
 import { getTranslate, getActiveLanguage } from 'react-localize-redux';
 import { fetchWorkflow, toggleSelection } from '../ducks/workflow';
 import { fetchSubject } from '../ducks/subject';
+import { WorkInProgress } from '../ducks/work-in-progress';
 import { config } from '../config';
 
 const WorkflowDropdown = ({ className, dispatch, history, translate, workflow, activeAnnotationExists }) => {
@@ -133,10 +134,19 @@ WorkflowDropdown.defaultProps = {
   translate: () => {},
 };
 
-const mapStateToProps = state => ({
-  activeAnnotationExists: !!state.workflow.data && !!state.subject.currentSubject,
-  currentLanguage: getActiveLanguage(state.locale).code,
-  translate: getTranslate(state.locale)
-});
+const mapStateToProps = state => {
+  const user = state.login.user;
+  const userHasWorkInProgress = user && WorkInProgress.check(user);
+  
+  return {
+    //Does the user currently have a page being actively annotated (e.g. user
+    //navigated away from the Classifier page), or saved work in progress?
+    //(e.g. user reloaded the website)
+    activeAnnotationExists: (!!state.workflow.data && !!state.subject.currentSubject) || userHasWorkInProgress,
+    currentLanguage: getActiveLanguage(state.locale).code,
+    translate: getTranslate(state.locale),
+    user: state.login.user,  //Needed, otherwise component won't update when it detects a user login.
+  };
+};
 
 export default connect(mapStateToProps)(withRouter(WorkflowDropdown));

--- a/src/components/WorkflowDropdown.jsx
+++ b/src/components/WorkflowDropdown.jsx
@@ -139,9 +139,11 @@ const mapStateToProps = state => {
   const userHasWorkInProgress = user && WorkInProgress.check(user);
   
   return {
-    //Does the user currently have a page being actively annotated (e.g. user
-    //navigated away from the Classifier page), or saved work in progress?
-    //(e.g. user reloaded the website)
+    //Does the user currently have a page being actively annotated, (e.g. user
+    //navigated away from the Classifier page and wants to return), or have
+    //saved work in progress? (e.g. user reloaded the website after a crash)
+    //We need to know if the user has any work that can be retrieved (either
+    //from the Redux store of local storage) so we can prompt them to continue.
     activeAnnotationExists: (!!state.workflow.data && !!state.subject.currentSubject) || userHasWorkInProgress,
     currentLanguage: getActiveLanguage(state.locale).code,
     translate: getTranslate(state.locale),

--- a/src/ducks/aggregations.js
+++ b/src/ducks/aggregations.js
@@ -126,12 +126,12 @@ const fetchAggregations = (subjectId, workflowId) => {
         dispatch({ type: FETCH_AGGREGATIONS_SUCCESS, aggregationData: newData });
       });
 
-    const fetchWorkflow = apiClient.type('workflows').get({ id: config.keywordWorkflow })
+    const fetchKeywordWorkflow = apiClient.type('workflows').get({ id: config.keywordWorkflow })
       .then(([keywordWorkflow]) => {
         dispatch({ type: FETCH_KEYWORD_WORKFLOW_SUCCESS, keywordWorkflow });
       });
 
-    Promise.all([fetchData, fetchWorkflow]).then(() => {
+    Promise.all([fetchData, fetchKeywordWorkflow]).then(() => {
       dispatch({ type: FETCH_AGGREGATION_RESOURCES_SUCCESS });
     }).catch(() => {
       dispatch({ type: FETCH_AGGREGATION_RESOURCES_ERROR });

--- a/src/ducks/initialize.js
+++ b/src/ducks/initialize.js
@@ -1,5 +1,4 @@
 import { fetchProject } from './project';
-import { fetchWorkflow } from './workflow';
 import { fetchGuide } from './field-guide';
 import { initializeLanguages } from './languages';
 

--- a/src/ducks/workflow.js
+++ b/src/ducks/workflow.js
@@ -61,7 +61,7 @@ const prepareForNewWorkflow = () => {
   return (dispatch) => {
     dispatch(resetSubject());
     dispatch(resetAnnotations());
-    dispatch(fetchSubject());
+    //dispatch(fetchSubject());  //Don't fetch Subject immediately. use dispatch(prepareForNewWorkflow()).then(()=>{ return dispatch(fetchSubject()) })
     dispatch(fetchTutorial());
   };
 };

--- a/src/locales/ar.js
+++ b/src/locales/ar.js
@@ -77,6 +77,17 @@ export default {
     startNewWork: 'New Page',
     resumeWorkInProgress: 'Resume Work',
   },
+  general: {
+    hebrew: 'Hebrew',
+    arabic: 'Arabic',
+    comingSoon: 'Coming Soon!',
+  },
+  workflowSelection: {
+    phaseOne: 'Phase One: Classify Fragments',
+    phaseTwo: 'Phase Two: Full Text Transcription',
+    keywordSearch: 'Keyword Search',
+    continue: 'Continue work in progress',
+  },
   tutorial: {
     title: 'الدرس التعليمي'
   },

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -38,6 +38,17 @@ export default {
     startNewWork: 'New Page',
     resumeWorkInProgress: 'Resume Work',
   },
+  general: {
+    hebrew: 'Hebrew',
+    arabic: 'Arabic',
+    comingSoon: 'Coming Soon!',
+  },
+  workflowSelection: {
+    phaseOne: 'Phase One: Classify Fragments',
+    phaseTwo: 'Phase Two: Full Text Transcription',
+    keywordSearch: 'Keyword Search',
+    continue: 'Continue work in progress',
+  },
   tutorial: {
     title: 'Tutorial'
   },

--- a/src/locales/he.js
+++ b/src/locales/he.js
@@ -38,6 +38,17 @@ export default {
     startNewWork: 'New Page',
     resumeWorkInProgress: 'Resume Work',
   },
+  general: {
+    hebrew: 'Hebrew',
+    arabic: 'Arabic',
+    comingSoon: 'Coming Soon!',
+  },
+  workflowSelection: {
+    phaseOne: 'Phase One: Classify Fragments',
+    phaseTwo: 'Phase Two: Full Text Transcription',
+    keywordSearch: 'Keyword Search',
+    continue: 'Continue work in progress',
+  },
   tutorial: {
     title: 'הדרכה'
   },


### PR DESCRIPTION
## PR Overview
This PR fixes several issues with the "Resume Progress" (i.e. retrieving data from localStorage) feature.

The fixes include:
- Resume Progress actually allows you to resume your progress!
  - Prior to this PR, Resumed Progress would have been immediately overwritten by a new fetched subject. This was a conflict introduced with the recent "Select Workflow" update.
  - The fix: fetchWorkflow() no longer automatically calls fetchSubject(). fetchSubject() has to be chained using a Promise.then().
- If the user either has an **active annotation** (e.g. the user started working on the Classifier, then navigated away to the About page, and now want to come back) or **saved progress** (i.e. localStorage save), the Workflow Selection dropdown now provides the option of continuing their work.
  - Prior to this PR, if the user navigates away from the Classifier page, they would have no way of going straight back to the /classify page, and would have been prompted to select a new Workflow, no matter what.
- If the user accesses the Classifier page, and they have BOTH an active annotation (e.g. they did some work, navigated to the About page, then came back) and saved progress (i.e. they clicked "Save Progress" at some point), the Resume Progress prompt will NOT appear.
  - This is because we assume that the only time both conditions can be true is if a user navigated away from the Classifier page then returned. Hence, there's no need to Resume Progress - they already have an active annotation they intend to continue with.

Side updates include:
- New translations have been added, notably for the Workflow Selection component.


### Status
Merging.