### PR TITLE
Update PJC to 2.9.7 so login states persist across windows/tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "history": "~4.6.3",
     "lodash": "~4.17.10",
     "markdownz": "~7.3.1",
-    "panoptes-client": "~2.9.6",
+    "panoptes-client": "~2.9.7",
     "prop-types": "~15.5.10",
     "publisssh": "^1.1.0",
     "react": "~15.6.1",


### PR DESCRIPTION
## PR Overview
This PR solves an issue where, if a logged in user opens a new tab/window to Scribes, the new tab/window doesn't realise that the user _should still be logged in._

This issue stemmed from Panoptes JavaScript Client 2.9.6's use of sessionStorage to keep the "user is logged in" indicator, and this sessionStorage data doesn't persist data between tabs/windows. 2.9.7 fixes this by using localStorage.

Also fixes #78 , which occurs because the user isn't logged in when they access the website on a new window/tab. (Hence, the Resume Progress prompt wouldn't trigger.)

### Status
Tests look good on localhost, deploying to production to test on a live environment and _then_ merging. (I'm so sorry, we don't have staging, and production isn't being actively used right now.)

@wgranger @snblickhan This is just a note to confirm that we _no longer_ need a "Please Sign In!" prompt at the Classifier page, like we do on ASM. I proposed that earlier as a stopgap measure, but this update to the PJC is the _proper_ long-term solution.