### PR TITLE
Adjust Workflow Selection Logic

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -51,12 +51,14 @@ App.propTypes = {
   initializerReady: PropTypes.bool,
   location: PropTypes.shape({
     pathname: PropTypes.string
-  })
+  }),
+  popup: PropTypes.node
 };
 
 App.defaultProps = {
   initializerReady: false,
-  location: {}
+  location: {},
+  popup: null
 };
 
 const mapStateToProps = state => ({

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -38,6 +38,8 @@ class App extends React.Component {
           </Switch>
         </section>
 
+        {this.props.popup}
+
         <div className="grommet">
           <ZooFooter />
         </div>
@@ -62,7 +64,8 @@ App.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-  initializerReady: state.initialize.ready
+  initializerReady: state.initialize.ready,
+  popup: state.dialog.popup
 });
 
 export default connect(mapStateToProps)(App);

--- a/src/components/Dialog.jsx
+++ b/src/components/Dialog.jsx
@@ -13,6 +13,10 @@ class Dialog extends React.Component {
     this.moveToFront = this.moveToFront.bind(this);
   }
 
+  componentDidMount() {
+    this.moveToFront();
+  }
+
   onClose() {
     if (this.props.isAnnotation) {
       this.props.dispatch(toggleAnnotation(null));

--- a/src/components/ProjectHeader.jsx
+++ b/src/components/ProjectHeader.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { getTranslate, getActiveLanguage } from 'react-localize-redux';
 
 import { config } from '../config.js';
-import WorkflowDropdown from './WorkflowDropdown';
+import WorkflowSelection from './WorkflowSelection';
 
 import { setLanguage, LANGUAGES } from '../ducks/languages';
 import { toggleSelection } from '../ducks/workflow';
@@ -68,7 +68,7 @@ class ProjectHeader extends React.Component {
                 {this.props.translate('topNav.transcribe')}
               </button>
               {this.props.showWorkflows && (
-                <WorkflowDropdown />
+                <WorkflowSelection showAllWorkflows={false} />
               )}
               <a
                 className="project-header__link"

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -62,6 +62,9 @@ class SelectedAnnotation extends React.Component {
     let text = '';
     if (this.props.selectedAnnotation.details) {
       text = this.props.selectedAnnotation.details[0].value;
+      if (text.length) {
+        this.setState({ disableSubmit: false });
+      }
     }
     this.inputText.value = text;
     this.inputText.focus();

--- a/src/components/StartNewWorkConfirmation.jsx
+++ b/src/components/StartNewWorkConfirmation.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import QuestionPrompt from './QuestionPrompt';
+import WorkflowPrompt from './WorkflowPrompt';
+import { clearWorkflow, toggleSelection } from '../ducks/workflow';
+import { togglePopup } from '../ducks/dialog';
+import { WorkInProgress } from '../ducks/work-in-progress';
+import { resetSubject } from '../ducks/subject';
+
+class StartNewWorkConfirmation extends React.Component {
+  constructor() {
+    super();
+
+    this.startNewWork = this.startNewWork.bind(this);
+    this.continueWork = this.continueWork.bind(this);
+  }
+
+  proceedToClassifier() {
+    this.props.dispatch(toggleSelection(false));
+    this.props.dispatch(togglePopup(null));
+    this.props.history.push('/classify');
+    window.scrollTo(0, 0);
+  }
+
+  startNewWork() {
+    if (this.props.user && WorkInProgress.check(this.props.user)) {
+      this.props.dispatch(WorkInProgress.clear());
+    } else {
+      this.props.dispatch(clearWorkflow());
+      this.props.dispatch(resetSubject());
+    }
+    this.proceedToClassifier();
+    this.props.dispatch(togglePopup(<WorkflowPrompt />));
+  }
+
+  continueWork() {
+    if (this.props.user && WorkInProgress.check(this.props.user)) {
+      this.props.dispatch(WorkInProgress.load());
+    }
+    this.proceedToClassifier();
+  }
+
+  render() {
+    return (
+      <QuestionPrompt
+        confirm="Yes, start a new page"
+        deny="No, continue saved progress"
+        onConfirm={this.startNewWork}
+        onDeny={this.continueWork}
+        question="Are you sure you want to start a new workflow? This will delete any saved work you may have."
+        title="Start new Work?"
+      />
+    );
+  }
+}
+
+StartNewWorkConfirmation.propTypes = {
+  dispatch: PropTypes.func.isRequired,
+  history: PropTypes.shape({
+    push: PropTypes.func
+  }).isRequired,
+  user: PropTypes.shape({
+    id: PropTypes.string
+  })
+};
+
+StartNewWorkConfirmation.defaultProps = {
+  user: null
+};
+
+const mapStateToProps = state => {
+  const user = state.login.user;
+  const userHasWorkInProgress = user && WorkInProgress.check(user);
+
+  return {
+    activeAnnotationExists: (!!state.workflow.data && !!state.subject.currentSubject) || userHasWorkInProgress,
+    user: state.login.user
+  };
+};
+
+export default connect(mapStateToProps)(withRouter(StartNewWorkConfirmation));

--- a/src/components/StartNewWorkConfirmation.jsx
+++ b/src/components/StartNewWorkConfirmation.jsx
@@ -4,10 +4,9 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import QuestionPrompt from './QuestionPrompt';
 import WorkflowPrompt from './WorkflowPrompt';
-import { clearWorkflow, toggleSelection } from '../ducks/workflow';
+import { toggleSelection } from '../ducks/workflow';
 import { togglePopup } from '../ducks/dialog';
 import { WorkInProgress } from '../ducks/work-in-progress';
-import { resetSubject } from '../ducks/subject';
 
 class StartNewWorkConfirmation extends React.Component {
   constructor() {
@@ -27,9 +26,6 @@ class StartNewWorkConfirmation extends React.Component {
   startNewWork() {
     if (this.props.user && WorkInProgress.check(this.props.user)) {
       this.props.dispatch(WorkInProgress.clear());
-    } else {
-      this.props.dispatch(clearWorkflow());
-      this.props.dispatch(resetSubject());
     }
     this.proceedToClassifier();
     this.props.dispatch(togglePopup(<WorkflowPrompt />));
@@ -46,7 +42,7 @@ class StartNewWorkConfirmation extends React.Component {
     return (
       <QuestionPrompt
         confirm="Yes, start a new page"
-        deny="No, continue saved progress"
+        deny="No, continue saved work"
         onConfirm={this.startNewWork}
         onDeny={this.continueWork}
         question="Are you sure you want to start a new workflow? This will delete any saved work you may have."

--- a/src/components/WorkInProgressPopup.jsx
+++ b/src/components/WorkInProgressPopup.jsx
@@ -6,33 +6,25 @@ import { getTranslate } from 'react-localize-redux';
 import { togglePopup } from '../ducks/dialog';
 import { WorkInProgress } from '../ducks/work-in-progress';
 
+import StartNewWorkConfirmation from './StartNewWorkConfirmation';
+
 class WorkInProgressPopup extends React.Component {
   constructor() {
     super();
 
-    this.closePopup = this.closePopup.bind(this);
     this.resumeWorkInProgress = this.resumeWorkInProgress.bind(this);
-    this.startNewWork = this.startNewWork.bind(this);
+    this.newWorkPrompt = this.newWorkPrompt.bind(this);
   }
 
-  closePopup() {
-    this.props.dispatch(togglePopup(null));
-  }
-  
   resumeWorkInProgress() {
     this.props.dispatch(WorkInProgress.load());
-    this.closePopup();
+    this.props.dispatch(togglePopup(null));
   }
-  
-  startNewWork() {
-    this.props.dispatch(WorkInProgress.clear());
-    this.closePopup();
-    
-    //HACK  //TODO
-    //Due to the new workflow selection feature, we need to trigger a series of
-    //refreshes to allow the Classifier page to show the WorkflowDropdown
-    //module. This requires a more elegant solution.
-    window.location.reload();
+
+  newWorkPrompt() {
+    this.props.dispatch(togglePopup(
+      <StartNewWorkConfirmation />
+    ));
   }
 
   render() {
@@ -48,7 +40,7 @@ class WorkInProgressPopup extends React.Component {
               </p>
             </div>
             <div className="work-in-progress-popup__controls">
-              <button className="button" onClick={this.startNewWork}>{this.props.translate('workInProgress.startNewWork')}</button>
+              <button className="button" onClick={this.newWorkPrompt}>{this.props.translate('workInProgress.startNewWork')}</button>
               <button className="button button__dark" onClick={this.resumeWorkInProgress}>{this.props.translate('workInProgress.resumeWorkInProgress')}</button>
             </div>
           </div>
@@ -59,13 +51,12 @@ class WorkInProgressPopup extends React.Component {
 }
 
 WorkInProgressPopup.propTypes = {
-  dispatch: PropTypes.func,
-  translate: PropTypes.func,
+  dispatch: PropTypes.func.isRequired,
+  translate: PropTypes.func
 };
 
 WorkInProgressPopup.defaultProps = {
-  dispatch: () => {},
-  translate: () => {},
+  translate: () => {}
 };
 
 const mapStateToProps = (state) => {

--- a/src/components/WorkInProgressPopup.jsx
+++ b/src/components/WorkInProgressPopup.jsx
@@ -40,8 +40,18 @@ class WorkInProgressPopup extends React.Component {
               </p>
             </div>
             <div className="work-in-progress-popup__controls">
-              <button className="button" onClick={this.newWorkPrompt}>{this.props.translate('workInProgress.startNewWork')}</button>
-              <button className="button button__dark" onClick={this.resumeWorkInProgress}>{this.props.translate('workInProgress.resumeWorkInProgress')}</button>
+              <button
+                className="button"
+                onClick={this.newWorkPrompt}
+              >
+                {this.props.translate('workInProgress.startNewWork')}
+              </button>
+              <button
+                className="button button__dark"
+                onClick={this.resumeWorkInProgress}
+              >
+                {this.props.translate('workInProgress.resumeWorkInProgress')}
+              </button>
             </div>
           </div>
         </div>

--- a/src/components/WorkflowPrompt.jsx
+++ b/src/components/WorkflowPrompt.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import WorkflowDropdown from './WorkflowDropdown';
+import WorkflowSelection from './WorkflowSelection';
 
 const WorkflowPrompt = () => {
   return (
@@ -9,7 +9,7 @@ const WorkflowPrompt = () => {
           <span>Choose a Workflow</span>
           <hr className="plum-line" />
         </div>
-        <WorkflowDropdown className="workflow-prompt-popup" />
+        <WorkflowSelection className="workflow-prompt-popup" />
       </div>
     </div>
   );

--- a/src/components/WorkflowSelection.jsx
+++ b/src/components/WorkflowSelection.jsx
@@ -1,0 +1,187 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import { getTranslate, getActiveLanguage } from 'react-localize-redux';
+import { fetchWorkflow, toggleSelection } from '../ducks/workflow';
+import { fetchSubject } from '../ducks/subject';
+import { WorkInProgress } from '../ducks/work-in-progress';
+import { togglePopup } from '../ducks/dialog';
+import { config } from '../config';
+import StartNewWorkConfirmation from './StartNewWorkConfirmation';
+
+const WorkflowSelection = ({ className, dispatch, history, translate, showAllWorkflows, activeAnnotationExists }) => {
+  const proceedToClassifier = () => {
+    dispatch(toggleSelection(false));
+    dispatch(togglePopup(null));
+    history.push('/classify');
+    window.scrollTo(0, 0);
+  };
+
+  const selectWorkflow = (workflow) => {
+    dispatch(fetchWorkflow(workflow)).then(()=>{
+      return dispatch(fetchSubject());
+    });
+    proceedToClassifier();
+  };
+
+  const newWorkPrompt = () => {
+    dispatch(togglePopup(
+      <StartNewWorkConfirmation />));
+  };
+
+  const makeSelection = (loadSaved) => {
+    if (loadSaved) {
+      dispatch(WorkInProgress.load());
+    } else if (activeAnnotationExists) {
+      return newWorkPrompt();
+    }
+    proceedToClassifier();
+  };
+
+  const c = config;
+  const classifyPath = `${c.host}projects/${c.projectSlug}/classify?workflow=`;
+  return (
+    <div className={`selection-container ${className}`}>
+      {(!activeAnnotationExists) ? null : (
+        <div>
+          <button
+            className="tertiary-label"
+            onClick={makeSelection.bind(this, true)}
+          >
+            {translate('workflowSelection.continue')}
+          </button>
+        </div>
+      )}
+
+      {!showAllWorkflows && (
+        <div>
+          <button
+            className="tertiary-label"
+            onClick={makeSelection.bind(this, false)}
+          >
+            Choose a Workflow
+          </button>
+        </div>
+      )}
+
+      {showAllWorkflows && (
+        <div>
+          <div>
+            <a
+              className="tertiary-label"
+              href={`${classifyPath}${c.phaseOne}`}
+              target="_blank"
+            >
+              {translate('workflowSelection.phaseOne')} <i className="fa fa-external-link" />
+            </a>
+          </div>
+          <div>
+            <span className="h1-font">{translate('general.hebrew')}</span>
+            <span className="primary-label">{translate('workflowSelection.phaseTwo')}</span>
+            <button
+              className="tertiary-label"
+              onClick={selectWorkflow.bind(null, c.easyHebrew)}
+            >
+              {translate('transcribeHebrew.easy')}
+            </button>
+            <div className="disabled-workflow">
+              <button
+                className="tertiary-label disabled-workflow"
+                disabled
+                onClick={selectWorkflow.bind(null, c.challengingHebrew)}
+              >
+                {translate('transcribeHebrew.challenging')}
+              </button>
+              <span>{translate('general.comingSoon')}</span>
+            </div>
+
+            <div>
+              <span className="primary-label">{translate('workflowSelection.keywordSearch')}</span>
+              <a
+                className="tertiary-label"
+                href={`${classifyPath}${c.hebrewKeyword}`}
+                target="_blank"
+              >
+                {translate('keywordsHebrew.button')} <i className="fa fa-external-link" />
+              </a>
+            </div>
+          </div>
+          <div>
+            <span className="h1-font">{translate('general.arabic')}</span>
+            <span className="primary-label">{translate('workflowSelection.phaseTwo')}</span>
+            <button
+              className="tertiary-label"
+              onClick={selectWorkflow.bind(null, c.easyArabic)}
+            >
+              {translate('transcribeArabic.easy')}
+            </button>
+            <div className="disabled-workflow">
+              <button
+                className="tertiary-label"
+                disabled
+                onClick={selectWorkflow.bind(null, c.challengingArabic)}
+              >
+                {translate('transcribeArabic.challenging')}
+              </button>
+              <span>{translate('general.comingSoon')}</span>
+            </div>
+
+            <div>
+              <span className="primary-label">{translate('workflowSelection.keywordSearch')}</span>
+              <a
+                className="tertiary-label"
+                href={`${classifyPath}${c.arabicKeyword}`}
+                target="_blank"
+              >
+                {translate('keywordsArabic.button')} <i className="fa fa-external-link" />
+              </a>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+WorkflowSelection.propTypes = {
+  activeAnnotationExists: PropTypes.bool,
+  className: PropTypes.string,
+  dispatch: PropTypes.func.isRequired,
+  history: PropTypes.shape({
+    push: PropTypes.func
+  }).isRequired,
+  showAllWorkflows: PropTypes.bool,
+  translate: PropTypes.func.isRequired
+};
+
+WorkflowSelection.defaultProps = {
+  activeAnnotationExists: false,
+  className: '',
+  dispatch: () => {},
+  history: {
+    push: () => {}
+  },
+  showAllWorkflows: true,
+  translate: () => {},
+  user: null
+};
+
+const mapStateToProps = state => {
+  const user = state.login.user;
+  const userHasWorkInProgress = user && WorkInProgress.check(user);
+
+  return {
+    //Does the user currently have a page being actively annotated, (e.g. user
+    //navigated away from the Classifier page and wants to return), or have
+    //saved work in progress? (e.g. user reloaded the website after a crash)
+    //We need to know if the user has any work that can be retrieved (either
+    //from the Redux store of local storage) so we can prompt them to continue.
+    activeAnnotationExists: (!!state.workflow.data && !!state.subject.currentSubject) || userHasWorkInProgress,
+    currentLanguage: getActiveLanguage(state.locale).code,
+    translate: getTranslate(state.locale),
+    user: state.login.user,  //Needed, otherwise component won't update when it detects a user login.
+  };
+};
+
+export default connect(mapStateToProps)(withRouter(WorkflowSelection));

--- a/src/components/WorkflowSelection.jsx
+++ b/src/components/WorkflowSelection.jsx
@@ -10,7 +10,7 @@ import { togglePopup } from '../ducks/dialog';
 import { config } from '../config';
 import StartNewWorkConfirmation from './StartNewWorkConfirmation';
 
-const WorkflowSelection = ({ className, dispatch, history, translate, showAllWorkflows, activeAnnotationExists }) => {
+const WorkflowSelection = ({ className, dispatch, location, history, translate, showAllWorkflows, activeAnnotationExists }) => {
   const proceedToClassifier = () => {
     dispatch(toggleSelection(false));
     dispatch(togglePopup(null));
@@ -43,7 +43,7 @@ const WorkflowSelection = ({ className, dispatch, history, translate, showAllWor
   const classifyPath = `${c.host}projects/${c.projectSlug}/classify?workflow=`;
   return (
     <div className={`selection-container ${className}`}>
-      {(!activeAnnotationExists) ? null : (
+      {(!activeAnnotationExists || location.pathname === '/classify') ? null : (
         <div>
           <button
             className="tertiary-label"
@@ -151,6 +151,9 @@ WorkflowSelection.propTypes = {
   history: PropTypes.shape({
     push: PropTypes.func
   }).isRequired,
+  location: PropTypes.shape({
+    pathname: PropTypes.string
+  }),
   showAllWorkflows: PropTypes.bool,
   translate: PropTypes.func.isRequired
 };
@@ -162,6 +165,7 @@ WorkflowSelection.defaultProps = {
   history: {
     push: () => {}
   },
+  location: {},
   showAllWorkflows: true,
   translate: () => {},
   user: null

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -366,7 +366,6 @@ class SubjectViewer extends React.Component {
       >
         {renderedItem}
 
-        {this.props.popup}
       </section>
     );
   }
@@ -391,7 +390,6 @@ SubjectViewer.propTypes = {
     width: PropTypes.number,
     height: PropTypes.number
   }),
-  popup: PropTypes.node,
   reminder: PropTypes.node,
   rotation: PropTypes.number,
   translationX: PropTypes.number,
@@ -418,7 +416,6 @@ SubjectViewer.defaultProps = {
   dispatch: () => {},
   frame: 0,
   imageSize: { width: 0, height: 0 },
-  popup: null,
   reminder: null,
   rotation: 0,
   scaling: 1,
@@ -444,7 +441,6 @@ const mapStateToProps = (state) => {
     currentSubject: state.subject.currentSubject,
     frame: sv.frame,
     imageSize: sv.imageSize,
-    popup: state.dialog.popup,
     reminder: state.reminder.node,
     rotation: sv.rotation,
     scaling: sv.scaling,

--- a/src/ducks/work-in-progress.js
+++ b/src/ducks/work-in-progress.js
@@ -25,10 +25,10 @@ class ReduxConnectedReactComponent {
 
     //Deletes any work in progress
     this.props.dispatch(WorkInProgress.clear());
-    
+
     //Saves any work in progress
     this.props.dispatch(WorkInProgress.clear());
-    
+
     //Loads any work in progress
     this.props.dispatch(WorkInProgress.clear());
   }
@@ -127,7 +127,7 @@ const wipReducer = (state = WORKINPROGRESS_INITIAL_STATE, action) => {
       return Object.assign({}, state, {
         wipTimestamp: action.timestamp,
       });
-    
+
     case CLEAR_TIMESTAMP:
       return Object.assign({}, state, {
         wipTimestamp: null,
@@ -154,9 +154,8 @@ const check = (user) => {
   const workflowId = localStorage.getItem(`${userId}.${WORKFLOW_ID_KEY}`);
   const subjectId = localStorage.getItem(`${userId}.${SUBJECT_ID_KEY}`);
   const annotations = localStorage.getItem(`${userId}.${ANNOTATIONS_KEY}`);
-
   return !!workflowId && !!subjectId && !!annotations;
-}
+};
 
 /*  Clears any work in progress the user has.
     Needs to be called via Redux's dispatch().
@@ -167,11 +166,11 @@ const clear = () => {
     localStorage.removeItem(`${userId}.${WORKFLOW_ID_KEY}`);
     localStorage.removeItem(`${userId}.${SUBJECT_ID_KEY}`);
     localStorage.removeItem(`${userId}.${ANNOTATIONS_KEY}`);
-    
+
     //Store update
     dispatch({ type: CLEAR_TIMESTAMP });
     console.log('WorkInProgress.clear()');
-  }
+  };
 };
 
 /*  Saves any work in progress the user has.
@@ -183,7 +182,7 @@ const save = () => {
     const workflowId = getState().workflow.id;
     const subjectId = getState().subject.id;
     const annotations = getState().annotations.annotations;
-    
+
     //Sanity check: make sure we have something to load.
     if (!workflowId || !subjectId || !annotations) {
       console.error('WorkInProgress.save() error: nothing to save.');
@@ -193,7 +192,7 @@ const save = () => {
     localStorage.setItem(`${userId}.${WORKFLOW_ID_KEY}`, workflowId);
     localStorage.setItem(`${userId}.${SUBJECT_ID_KEY}`, subjectId);
     localStorage.setItem(`${userId}.${ANNOTATIONS_KEY}`, JSON.stringify(annotations));
-    
+
     //Store update
     dispatch({ type: SET_TIMESTAMP, timestamp: new Date(Date.now()) });
     console.log('WorkInProgress.save() success');
@@ -211,13 +210,13 @@ const load = () => {
       const workflowId = localStorage.getItem(`${userId}.${WORKFLOW_ID_KEY}`);
       const subjectId = localStorage.getItem(`${userId}.${SUBJECT_ID_KEY}`);  //TODO: Check if a type conversion is required.
       const annotations = JSON.parse(localStorage.getItem(`${userId}.${ANNOTATIONS_KEY}`));
-      
+
       //Sanity check: make sure we have something to load.
       if (!workflowId || !subjectId || !annotations) {
         console.error('WorkInProgress.save() error: nothing to load.');
         return;
       }
-      
+
       //First, load the Workflow, then the Subject, then the Annotations.
       dispatch(fetchWorkflow(workflowId)).then(() => {
         return dispatch(fetchSubject(subjectId));
@@ -225,11 +224,11 @@ const load = () => {
         return dispatch(loadAnnotations(annotations));
       }).then(() => {
         console.log('WorkInProgress.load() success');
-        
+
         //If we want to remove all saved progress when a user successfully
         //loads their data, enable this following line:
         //  return dispatch(clear());
-        
+
         return null;
       });
     } catch (err) {
@@ -252,7 +251,7 @@ const WorkInProgress = {
   check,
   save,
   load,
-  clear,  
+  clear,
 };
 
 /*

--- a/src/ducks/work-in-progress.js
+++ b/src/ducks/work-in-progress.js
@@ -94,7 +94,7 @@ const WORKINPROGRESS_INITIAL_STATE = {
       };
  */
 const WORKINPROGRESS_PROPTYPES = {
-  wipTimestamp: PropTypes.object,
+  wipTimestamp: PropTypes.object
 };
 
 /*  Used as a convenience feature in mapStateToProps() functions in
@@ -110,7 +110,7 @@ const WORKINPROGRESS_PROPTYPES = {
  */
 const getWorkInProgressStateValues = (state) => {
   return {
-    wipTimestamp: state[REDUX_STORE_NAME].wipTimestamp,
+    wipTimestamp: state[REDUX_STORE_NAME].wipTimestamp
   };
 };
 
@@ -125,17 +125,17 @@ const wipReducer = (state = WORKINPROGRESS_INITIAL_STATE, action) => {
   switch (action.type) {
     case SET_TIMESTAMP:
       return Object.assign({}, state, {
-        wipTimestamp: action.timestamp,
+        wipTimestamp: action.timestamp
       });
 
     case CLEAR_TIMESTAMP:
       return Object.assign({}, state, {
-        wipTimestamp: null,
+        wipTimestamp: null
       });
 
     default:
       return state;
-  };
+  }
 };
 
 /*
@@ -251,7 +251,7 @@ const WorkInProgress = {
   check,
   save,
   load,
-  clear,
+  clear
 };
 
 /*
@@ -267,5 +267,5 @@ export {
   WorkInProgress,
   WORKINPROGRESS_INITIAL_STATE,
   WORKINPROGRESS_PROPTYPES,
-  getWorkInProgressStateValues,
+  getWorkInProgressStateValues
 };

--- a/src/ducks/workflow.js
+++ b/src/ducks/workflow.js
@@ -12,6 +12,7 @@ const FETCH_WORKFLOW = 'FETCH_WORKFLOW';
 const FETCH_WORKFLOW_SUCCESS = 'FETCH_WORKFLOW_SUCCESS';
 const FETCH_WORKFLOW_ERROR = 'FETCH_WORKFLOW_ERROR';
 const TOGGLE_SELECTION = 'TOGGLE_SELECTION';
+const CLEAR_WORKFLOW = 'CLEAR_WORKFLOW';
 
 const WORKFLOW_STATUS = {
   IDLE: 'workflow_status_idle',
@@ -53,6 +54,9 @@ const workflowReducer = (state = initialState, action) => {
       return Object.assign({}, state, {
         showSelection: action.show
       });
+
+    case CLEAR_WORKFLOW:
+      return initialState;
 
     default:
       return state;
@@ -107,9 +111,16 @@ const toggleSelection = (show) => {
   };
 };
 
+const clearWorkflow = () => {
+  return (dispatch) => {
+    dispatch({ type: CLEAR_WORKFLOW });
+  };
+};
+
 export default workflowReducer;
 
 export {
+  clearWorkflow,
   fetchWorkflow,
   toggleSelection,
   WORKFLOW_STATUS

--- a/src/styles/components/project-header.styl
+++ b/src/styles/components/project-header.styl
@@ -46,7 +46,7 @@
   &__rtl
     flex-direction: row-reverse
 
-    div:last-child
+    > div:last-child
       flex-direction: row-reverse
 
   &__active


### PR DESCRIPTION
This branch does a good bit of work on the workflow selection logic. I suggest a keen eye on the changes made here, as there are a good bit and several different paths a user may take when starting a new workflow, resuming work, opening the classifier first vs. navigating from the landing page, etc. 

I also fixed a bug where a user couldn't select "done" on a `SelectedAnnotation` unless the textfield was altered.

Note: `WorkflowDropdown` was retitled as `WorkflowSelection` to better reflect what it actually is. The main changes to that component are conditions to hide all workflows unless necessary, hence the new `showAllWorkflows` prop.

~~WIP as I attempt to refactor~~