### PR TITLE
Finish Stats Section

### DIFF
--- a/src/components/HomeStatistics.jsx
+++ b/src/components/HomeStatistics.jsx
@@ -1,42 +1,65 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import Connect from './Connect';
 
-export default function HomeStatistics() {
-  return (
-    <div className="statistics">
-      <div className="statistics__stat-content">
-        <div className="statistics__pie-chart">
-          <svg viewBox="0 0 200 200">
-            <circle cx="100" cy="100" r="100" fill="#EBDFD6" stroke="#472B36" strokeWidth="5px" />
-            <path d="M100 100 L 100,0 A100,100 0 0,1 200,100 z" fill="#472B36" />
-          </svg>
-          <span>Percent Complete</span>
-          <hr className="plum-line" />
-        </div>
-        <div className="statistics__statistics">
-          <h2>Statistics from phase two of Scribes of the Cairo Geniza</h2>
-          <div className="statistics__stat">
-            <div>
-              <span>831</span>
-              <span>Volunteers</span>
-              <hr className="plum-line" />
-            </div>
-            <div>
-              <span>12,473</span>
-              <span>Classifications</span>
-              <hr className="plum-line" />
-            </div>
-            <div>
-              <span>3,147</span>
-              <span>Completed Subjects</span>
-              <hr className="plum-line" />
-            </div>
+class HomeStatistics extends React.Component {
+  render() {
+    const project = this.props.project;
+    if (!project) return null;
+
+    return (
+      <div className="statistics">
+        <div className="statistics__stat-content">
+          <div className="statistics__pie-chart">
+            <svg viewBox="0 0 200 200">
+              <circle cx="100" cy="100" r="100" fill="#EBDFD6" stroke="#472B36" strokeWidth="5px" />
+              <path d="M100 100 L 100,0 A100,100 0 0,1 200,100 z" fill="#472B36" />
+            </svg>
+            <span>Percent Complete</span>
+            <hr className="plum-line" />
           </div>
-          <a href="/" className="text-links">More statistics</a>
-          <a href="/" className="text-links">Phase One statistics</a>
+          <div className="statistics__statistics">
+            <h2>Statistics from phase two of Scribes of the Cairo Geniza</h2>
+            <div className="statistics__stat">
+              <div>
+                <span>{project.classifiers_count.toLocaleString() || 0}</span>
+                <span>Volunteers</span>
+                <hr className="plum-line" />
+              </div>
+              <div>
+                <span>{project.classifications_count.toLocaleString() || 0}</span>
+                <span>Classifications</span>
+                <hr className="plum-line" />
+              </div>
+              <div>
+                <span>{project.retired_subjects_count.toLocaleString() || 0}</span>
+                <span>Completed Subjects</span>
+                <hr className="plum-line" />
+              </div>
+            </div>
+            <a href="/" className="text-links">More statistics</a>
+            <a href="/" className="text-links">Phase One statistics</a>
+          </div>
         </div>
+        <Connect />
       </div>
-      <Connect />
-    </div>
-  );
+    );
+  }
 }
+
+HomeStatistics.propTypes = {
+  project: PropTypes.shape({
+    id: PropTypes.string
+  })
+};
+
+HomeStatistics.defaultProps = {
+  project: null
+};
+
+const mapStateToProps = state => ({
+  project: state.project.data
+});
+
+export default connect(mapStateToProps)(HomeStatistics);

--- a/src/components/HomeStatistics.jsx
+++ b/src/components/HomeStatistics.jsx
@@ -1,22 +1,57 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { fetchPhaseTwoWorkflows } from '../ducks/workflow';
+import { config } from '../config';
 import Connect from './Connect';
 
 class HomeStatistics extends React.Component {
+  componentDidMount() {
+    this.props.dispatch(fetchPhaseTwoWorkflows());
+  }
+
+  getCoordinatesForPercent(percent) {
+    const x = Math.cos(2 * Math.PI * percent);
+    const y = Math.sin(2 * Math.PI * percent);
+    return { x, y };
+  }
+
   render() {
     const project = this.props.project;
+    const workflows = this.props.allWorkflows;
     if (!project) return null;
+    let classificationsCount = 0;
+    let retiredSubjects = 0;
+    let subjectsCount = 0;
+    let percentComplete = 0;
+
+    Object.keys(workflows).map((id) => {
+      if (workflows[id] && workflows[id].classifications_count) {
+        classificationsCount += workflows[id].classifications_count;
+      }
+      if (workflows[id] && workflows[id].retired_set_member_subjects_count) {
+        retiredSubjects += workflows[id].retired_set_member_subjects_count;
+      }
+      if (workflows[id] && workflows[id].subjects_count) {
+        subjectsCount += workflows[id].subjects_count;
+      }
+    });
+
+    if (retiredSubjects && subjectsCount) {
+      percentComplete = (retiredSubjects / subjectsCount);
+    }
+    const pieChartCoor = this.getCoordinatesForPercent(percentComplete);
+    const arcSize = percentComplete > 0.5 ? 1 : 0;
 
     return (
       <div className="statistics">
         <div className="statistics__stat-content">
           <div className="statistics__pie-chart">
-            <svg viewBox="0 0 200 200">
-              <circle cx="100" cy="100" r="100" fill="#EBDFD6" stroke="#472B36" strokeWidth="5px" />
-              <path d="M100 100 L 100,0 A100,100 0 0,1 200,100 z" fill="#472B36" />
+            <svg viewBox="-1 -1 2 2" style={{ transform: 'rotate(-90deg)' }}>
+              <circle cx="0" cy="0" r="1" fill="#EBDFD6" stroke="#472B36" strokeWidth="0.05" />
+              <path d={`M 1 0 A 1 1 0 ${arcSize} 1 ${pieChartCoor.x} ${pieChartCoor.y} L 0 0`} fill="#472B36" />
             </svg>
-            <span>Percent Complete</span>
+            <span>{Math.floor(percentComplete * 100)}% Complete</span>
             <hr className="plum-line" />
           </div>
           <div className="statistics__statistics">
@@ -28,18 +63,23 @@ class HomeStatistics extends React.Component {
                 <hr className="plum-line" />
               </div>
               <div>
-                <span>{project.classifications_count.toLocaleString() || 0}</span>
+                <span>{classificationsCount.toLocaleString()}</span>
                 <span>Classifications</span>
                 <hr className="plum-line" />
               </div>
               <div>
-                <span>{project.retired_subjects_count.toLocaleString() || 0}</span>
+                <span>{retiredSubjects.toLocaleString()}</span>
                 <span>Completed Subjects</span>
                 <hr className="plum-line" />
               </div>
             </div>
-            <a href="/" className="text-links">More statistics</a>
-            <a href="/" className="text-links">Phase One statistics</a>
+            <a
+              className="text-links"
+              href={`${config.host}projects/${config.projectSlug}/stats`}
+              target="_blank"
+            >
+              More statistics
+            </a>
           </div>
         </div>
         <Connect />
@@ -49,16 +89,20 @@ class HomeStatistics extends React.Component {
 }
 
 HomeStatistics.propTypes = {
+  allWorkflows: PropTypes.object,
+  dispatch: PropTypes.func.isRequired,
   project: PropTypes.shape({
     id: PropTypes.string
   })
 };
 
 HomeStatistics.defaultProps = {
+  allWorkflows: {},
   project: null
 };
 
 const mapStateToProps = state => ({
+  allWorkflows: state.workflow.allWorkflows,
   project: state.project.data
 });
 

--- a/src/components/HomeStatistics.jsx
+++ b/src/components/HomeStatistics.jsx
@@ -17,23 +17,19 @@ class HomeStatistics extends React.Component {
   }
 
   render() {
-    const project = this.props.project;
-    const workflows = this.props.allWorkflows;
-    if (!project) return null;
+    const { project, allWorkflows } = this.props;
+    if (!project || !allWorkflows) return null;
     let classificationsCount = 0;
+    let percentComplete = 0;
     let retiredSubjects = 0;
     let subjectsCount = 0;
-    let percentComplete = 0;
 
-    Object.keys(workflows).map((id) => {
-      if (workflows[id] && workflows[id].classifications_count) {
-        classificationsCount += workflows[id].classifications_count;
-      }
-      if (workflows[id] && workflows[id].retired_set_member_subjects_count) {
-        retiredSubjects += workflows[id].retired_set_member_subjects_count;
-      }
-      if (workflows[id] && workflows[id].subjects_count) {
-        subjectsCount += workflows[id].subjects_count;
+    Object.keys(allWorkflows).map((id) => {
+      const workflow = allWorkflows[id];
+      if (workflow) {
+        classificationsCount += workflow.classifications_count;
+        retiredSubjects += workflow.retired_set_member_subjects_count;
+        subjectsCount += workflow.subjects_count;
       }
     });
 
@@ -63,12 +59,12 @@ class HomeStatistics extends React.Component {
                 <hr className="plum-line" />
               </div>
               <div>
-                <span>{classificationsCount.toLocaleString()}</span>
+                <span>{classificationsCount.toLocaleString() || 0}</span>
                 <span>Classifications</span>
                 <hr className="plum-line" />
               </div>
               <div>
-                <span>{retiredSubjects.toLocaleString()}</span>
+                <span>{retiredSubjects.toLocaleString() || 0}</span>
                 <span>Completed Subjects</span>
                 <hr className="plum-line" />
               </div>

--- a/src/ducks/workflow.js
+++ b/src/ducks/workflow.js
@@ -81,30 +81,41 @@ const prepareForNewWorkflow = () => {
 };
 
 const fetchWorkflow = (workflowId = config.easyHebrew) => {
-  return (dispatch) => {
+  return (dispatch, getState) => {
     dispatch({
       type: FETCH_WORKFLOW,
       id: workflowId
     });
 
-    return apiClient.type('workflows').get(workflowId)
-      .then((workflow) => {
-        const arabicWorkflows = [config.easyArabic, config.challengingArabic];
-        const manuscriptLanguage = arabicWorkflows.indexOf(workflow.id) >= 0 ? LANGUAGES.ARABIC : LANGUAGES.HEBREW;
+    const allWorkflows = getState().workflow.allWorkflows;
 
+    if (allWorkflows[workflowId]) {
+      return Promise.resolve(
         dispatch({
           type: FETCH_WORKFLOW_SUCCESS,
-          data: workflow,
-          manuscriptLanguage
-        });
+          data: allWorkflows[workflowId]
+        }),
+        dispatch(prepareForNewWorkflow())
+      );
+    } else {
+      return apiClient.type('workflows').get(workflowId)
+        .then((workflow) => {
+          const arabicWorkflows = [config.easyArabic, config.challengingArabic];
+          const manuscriptLanguage = arabicWorkflows.indexOf(workflow.id) >= 0 ? LANGUAGES.ARABIC : LANGUAGES.HEBREW;
 
-        // onSuccess(), prepare for a new workflow.
-        dispatch(toggleLanguage(manuscriptLanguage));
-        dispatch(prepareForNewWorkflow());
-      })
-      .catch(() => {
-        dispatch({ type: FETCH_WORKFLOW_ERROR });
-      });
+          dispatch({
+            type: FETCH_WORKFLOW_SUCCESS,
+            data: workflow,
+            manuscriptLanguage
+          });
+          dispatch(toggleLanguage(manuscriptLanguage));
+          dispatch(prepareForNewWorkflow());
+        })
+        .catch(() => {
+          dispatch({ type: FETCH_WORKFLOW_ERROR });
+        });
+    }
+>>>>>>> Adjust Data
   };
 };
 
@@ -126,12 +137,11 @@ const clearWorkflow = () => {
 
 const fetchPhaseTwoWorkflows = () => {
   return (dispatch) => {
-    const c = config;
     const allWorkflows = {
-      [c.easyHebrew]: null,
-      [c.challengingHebrew]: null,
-      [c.easyArabic]: null,
-      [c.challengingArabic]: null
+      [config.easyHebrew]: null,
+      [config.challengingHebrew]: null,
+      [config.easyArabic]: null,
+      [config.challengingArabic]: null
     };
     const calls = [];
 

--- a/src/ducks/workflow.js
+++ b/src/ducks/workflow.js
@@ -13,6 +13,7 @@ const FETCH_WORKFLOW_SUCCESS = 'FETCH_WORKFLOW_SUCCESS';
 const FETCH_WORKFLOW_ERROR = 'FETCH_WORKFLOW_ERROR';
 const TOGGLE_SELECTION = 'TOGGLE_SELECTION';
 const CLEAR_WORKFLOW = 'CLEAR_WORKFLOW';
+const FETCH_ALL_WORKFLOWS = 'FETCH_ALL_WORKFLOWS';
 
 const WORKFLOW_STATUS = {
   IDLE: 'workflow_status_idle',
@@ -23,6 +24,7 @@ const WORKFLOW_STATUS = {
 
 // Reducer
 const initialState = {
+  allWorkflows: {},
   data: null,
   id: null,
   manuscriptLanguage: LANGUAGES.HEBREW,
@@ -57,6 +59,11 @@ const workflowReducer = (state = initialState, action) => {
 
     case CLEAR_WORKFLOW:
       return initialState;
+
+    case FETCH_ALL_WORKFLOWS:
+      return Object.assign({}, state, {
+        allWorkflows: action.allWorkflows
+      });
 
     default:
       return state;
@@ -111,9 +118,40 @@ const toggleSelection = (show) => {
   };
 };
 
+
 const clearWorkflow = () => {
   return (dispatch) => {
     dispatch({ type: CLEAR_WORKFLOW });
+  };
+};
+
+const fetchPhaseTwoWorkflows = () => {
+  return (dispatch) => {
+    const c = config;
+    const allWorkflows = {
+      [c.easyHebrew]: null,
+      [c.challengingHebrew]: null,
+      [c.easyArabic]: null,
+      [c.challengingArabic]: null
+    };
+    const calls = [];
+
+    Object.keys(allWorkflows).map(id =>
+      calls.push(
+        apiClient.type('workflows').get(id)
+          .then((workflow) => {
+            if (workflow) {
+              allWorkflows[id] = workflow;
+            }
+          }))
+    );
+
+    Promise.all(calls).then(() => {
+      dispatch({
+        type: FETCH_ALL_WORKFLOWS,
+        allWorkflows
+      });
+    });
   };
 };
 
@@ -121,6 +159,7 @@ export default workflowReducer;
 
 export {
   clearWorkflow,
+  fetchPhaseTwoWorkflows,
   fetchWorkflow,
   toggleSelection,
   WORKFLOW_STATUS

--- a/src/ducks/workflow.js
+++ b/src/ducks/workflow.js
@@ -145,7 +145,7 @@ const fetchPhaseTwoWorkflows = () => {
     };
     const calls = [];
 
-    Object.keys(allWorkflows).map(id =>
+    Object.keys(allWorkflows).forEach(id =>
       calls.push(
         apiClient.type('workflows').get(id)
           .then((workflow) => {

--- a/src/ducks/workflow.js
+++ b/src/ducks/workflow.js
@@ -76,7 +76,6 @@ const prepareForNewWorkflow = () => {
   return (dispatch) => {
     dispatch(resetSubject());
     dispatch(resetAnnotations());
-    // dispatch(fetchSubject());  //Don't fetch Subject immediately. use dispatch(prepareForNewWorkflow()).then(()=>{ return dispatch(fetchSubject()) })
     dispatch(fetchTutorial());
   };
 };

--- a/src/ducks/workflow.js
+++ b/src/ducks/workflow.js
@@ -92,7 +92,6 @@ const fetchWorkflow = (workflowId = config.easyHebrew) => {
     const allWorkflows = getState().workflow.allWorkflows;
 
     if (allWorkflows[workflowId]) {
-      console.log('here');
       const manuscriptLanguage = ARABIC_WORKFLOWS.indexOf(workflowId) >= 0 ? LANGUAGES.ARABIC : LANGUAGES.HEBREW;
 
       return Promise.resolve(
@@ -105,7 +104,6 @@ const fetchWorkflow = (workflowId = config.easyHebrew) => {
         dispatch(prepareForNewWorkflow())
       );
     } else {
-      console.log('there');
       return apiClient.type('workflows').get(workflowId)
         .then((workflow) => {
           const manuscriptLanguage = ARABIC_WORKFLOWS.indexOf(workflow.id) >= 0 ? LANGUAGES.ARABIC : LANGUAGES.HEBREW;

--- a/src/ducks/workflow.js
+++ b/src/ducks/workflow.js
@@ -22,6 +22,8 @@ const WORKFLOW_STATUS = {
   ERROR: 'workflow_status_error'
 };
 
+const ARABIC_WORKFLOWS = [config.easyArabic, config.challengingArabic];
+
 // Reducer
 const initialState = {
   allWorkflows: {},
@@ -90,18 +92,21 @@ const fetchWorkflow = (workflowId = config.easyHebrew) => {
     const allWorkflows = getState().workflow.allWorkflows;
 
     if (allWorkflows[workflowId]) {
+      const manuscriptLanguage = ARABIC_WORKFLOWS.indexOf(workflowId) >= 0 ? LANGUAGES.ARABIC : LANGUAGES.HEBREW;
+
       return Promise.resolve(
         dispatch({
           type: FETCH_WORKFLOW_SUCCESS,
-          data: allWorkflows[workflowId]
+          data: allWorkflows[workflowId],
+          manuscriptLanguage
         }),
+        dispatch(toggleLanguage(manuscriptLanguage));
         dispatch(prepareForNewWorkflow())
       );
     } else {
       return apiClient.type('workflows').get(workflowId)
         .then((workflow) => {
-          const arabicWorkflows = [config.easyArabic, config.challengingArabic];
-          const manuscriptLanguage = arabicWorkflows.indexOf(workflow.id) >= 0 ? LANGUAGES.ARABIC : LANGUAGES.HEBREW;
+          const manuscriptLanguage = ARABIC_WORKFLOWS.indexOf(workflow.id) >= 0 ? LANGUAGES.ARABIC : LANGUAGES.HEBREW;
 
           dispatch({
             type: FETCH_WORKFLOW_SUCCESS,
@@ -115,7 +120,6 @@ const fetchWorkflow = (workflowId = config.easyHebrew) => {
           dispatch({ type: FETCH_WORKFLOW_ERROR });
         });
     }
->>>>>>> Adjust Data
   };
 };
 

--- a/src/ducks/workflow.js
+++ b/src/ducks/workflow.js
@@ -92,6 +92,7 @@ const fetchWorkflow = (workflowId = config.easyHebrew) => {
     const allWorkflows = getState().workflow.allWorkflows;
 
     if (allWorkflows[workflowId]) {
+      console.log('here');
       const manuscriptLanguage = ARABIC_WORKFLOWS.indexOf(workflowId) >= 0 ? LANGUAGES.ARABIC : LANGUAGES.HEBREW;
 
       return Promise.resolve(
@@ -100,10 +101,11 @@ const fetchWorkflow = (workflowId = config.easyHebrew) => {
           data: allWorkflows[workflowId],
           manuscriptLanguage
         }),
-        dispatch(toggleLanguage(manuscriptLanguage));
+        dispatch(toggleLanguage(manuscriptLanguage)),
         dispatch(prepareForNewWorkflow())
       );
     } else {
+      console.log('there');
       return apiClient.type('workflows').get(workflowId)
         .then((workflow) => {
           const manuscriptLanguage = ARABIC_WORKFLOWS.indexOf(workflow.id) >= 0 ? LANGUAGES.ARABIC : LANGUAGES.HEBREW;


### PR DESCRIPTION
This PR finishes the stats section on the homepage. Technically, it should be ready to merge, but it is marked RFC because I'd like to optimize one aspect of the code and would like a suggestion:

1) When the stats section loads, all workflows are retrieved to correctly calculate phase two stats, which makes it unnecessary to ever fetch another workflow once these are retrieved.
2) However, the `fetchWorkflow()` function returns a promise. If we instead said in that function "instead of an api call/promise, just return that workflow, if you already have it," the `fetchWorkflow()` calls in the app break because they expect a promise return to chain the `.then()` call when `fetchSubject()` is next called.
3) Any suggestions? This code works just fine without the optimization, but it would save a few API calls if we found a solution.