### PR TITLE
Resize Image and Toggle Instruction Text in English

### DIFF
--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -342,7 +342,12 @@ class SelectedAnnotation extends React.Component {
           <button className="close-button" onClick={this.closePrompt}>X</button>
         </div>
         <div className="selected-annotation__instructions">
-          <span>{translate('transcribeBox.instructions')}</span>
+          <span>
+            {this.props.currentLanguage === 'en' && (
+              `The ${this.props.manuscriptLanguage} `
+            )}
+            {translate('transcribeBox.instructions')}
+          </span>
           <span>{translate('transcribeBox.instructions2')}</span>
         </div>
         <input
@@ -472,6 +477,7 @@ SelectedAnnotation.propTypes = {
     name: PropTypes.string,
     type: PropTypes.string
   }),
+  currentLanguage: PropTypes.string.isRequired,
   dispatch: PropTypes.func,
   keyboardIndex: PropTypes.number,
   rtl: PropTypes.bool,

--- a/src/locales/ar.js
+++ b/src/locales/ar.js
@@ -77,18 +77,18 @@ export default {
     header: 'Resume Work In Progress?',
     message: 'We detected that you have some work in progress saved. You can continue your saved work, or start with a new page.',
     startNewWork: 'New Page',
-    resumeWorkInProgress: 'Resume Work',
+    resumeWorkInProgress: 'Resume Work'
   },
   general: {
-    hebrew: 'Hebrew',
-    arabic: 'Arabic',
-    comingSoon: 'Coming Soon!',
+    hebrew: 'عبري',
+    arabic: 'عربي',
+    comingSoon: 'Coming Soon!'
   },
   workflowSelection: {
     phaseOne: 'Phase One: Classify Fragments',
     phaseTwo: 'Phase Two: Full Text Transcription',
     keywordSearch: 'Keyword Search',
-    continue: 'Continue work in progress',
+    continue: 'Continue work in progress'
   },
   tutorial: {
     title: 'الدرس التعليمي'

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -38,25 +38,25 @@ export default {
     header: 'Resume Work In Progress?',
     message: 'We detected that you have some work in progress saved. You can continue your saved work, or start with a new page.',
     startNewWork: 'New Page',
-    resumeWorkInProgress: 'Resume Work',
+    resumeWorkInProgress: 'Resume Work'
   },
   general: {
     hebrew: 'Hebrew',
     arabic: 'Arabic',
-    comingSoon: 'Coming Soon!',
+    comingSoon: 'Coming Soon!'
   },
   workflowSelection: {
     phaseOne: 'Phase One: Classify Fragments',
     phaseTwo: 'Phase Two: Full Text Transcription',
     keywordSearch: 'Keyword Search',
-    continue: 'Continue work in progress',
+    continue: 'Continue work in progress'
   },
   tutorial: {
     title: 'Tutorial'
   },
   transcribeBox: {
     title: 'Transcribe',
-    instructions: 'The Hebrew language reads from right to left, so start on the right side.',
+    instructions: 'language reads from right to left, so start on the right side.',
     instructions2: 'Check out examples of different alphabets in the Crib Sheet',
     textArea: 'Text Area Content',
     openKeyboard: 'Open Keyboard',

--- a/src/locales/he.js
+++ b/src/locales/he.js
@@ -38,24 +38,25 @@ export default {
     header: 'Resume Work In Progress?',
     message: 'We detected that you have some work in progress saved. You can continue your saved work, or start with a new page.',
     startNewWork: 'New Page',
-    resumeWorkInProgress: 'Resume Work',
+    resumeWorkInProgress: 'Resume Work'
   },
   general: {
-    hebrew: 'Hebrew',
-    arabic: 'Arabic',
-    comingSoon: 'Coming Soon!',
+    hebrew: 'עברית',
+    arabic: 'ערבית',
+    comingSoon: 'Coming Soon!'
   },
   workflowSelection: {
     phaseOne: 'Phase One: Classify Fragments',
     phaseTwo: 'Phase Two: Full Text Transcription',
     keywordSearch: 'Keyword Search',
-    continue: 'Continue work in progress',
+    continue: 'Continue work in progress'
   },
   tutorial: {
     title: 'הדרכה'
   },
   transcribeBox: {
     title: 'תעתוק',
+    hebrew: 'עברית',
     instructions: 'הקלד את הטקסט שלפניך.',
     instructions2: 'ניתן להיעזר בדוגמאות סוגי כתב לשם זיהוי האותיות.',
     textArea: 'הקלד טקסט כאן',


### PR DESCRIPTION
This PR resizes the flipped scroll on the main page as the previous size was too large. The PR also adds appropriate instructional text on the `SelectedAnnotation` component for English. 

Note: this text toggle is only needed for English, as the translation for the text in Arabic reads ("The Hebrew language reads from right to left, starting from the right side") while the text in Hebrew reads ("Type the text below"). We'll have to wait for more specific/consistent translations in each language to make the switch there.