### PR TITLE
Introduce Admin Mode and Toggle

### DIFF
--- a/src/components/AdminToggle.jsx
+++ b/src/components/AdminToggle.jsx
@@ -19,7 +19,8 @@ const AdminToggle = ({ adminMode, toggleAdminMode, translate }) => {
 
 AdminToggle.propTypes = {
   adminMode: PropTypes.bool.isRequired,
-  toggleAdminMode: PropTypes.func.isRequired
+  toggleAdminMode: PropTypes.func.isRequired,
+  translate: PropTypes.func.isRequired
 };
 
 export default AdminToggle;

--- a/src/components/AdminToggle.jsx
+++ b/src/components/AdminToggle.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const AdminToggle = ({ adminMode, toggleAdminMode }) => {
+const AdminToggle = ({ adminMode, toggleAdminMode, translate }) => {
   return (
     <div className="admin-toggle">
       <input
@@ -11,7 +11,7 @@ const AdminToggle = ({ adminMode, toggleAdminMode }) => {
         type="checkbox"
       />
       <label htmlFor="admin">
-        <span>Admin</span>
+        <span>{translate('general.admin')}</span>
       </label>
     </div>
   );

--- a/src/components/AdminToggle.jsx
+++ b/src/components/AdminToggle.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const AdminToggle = ({ adminMode, toggleAdminMode }) => {
+  return (
+    <div className="admin-toggle">
+      <input
+        checked={adminMode}
+        id="admin"
+        onClick={toggleAdminMode}
+        type="checkbox"
+      />
+      <label htmlFor="admin">
+        <span>Admin</span>
+      </label>
+    </div>
+  );
+};
+
+AdminToggle.propTypes = {
+  adminMode: PropTypes.bool.isRequired,
+  toggleAdminMode: PropTypes.func.isRequired
+};
+
+export default AdminToggle;

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -10,7 +10,7 @@ import AboutLayout from './about';
 import AuthContainer from '../containers/AuthContainer';
 import ClassifierContainer from '../containers/ClassifierContainer';
 import Home from './Home';
-import ProjectHeader from './ProjectHeader';
+import ProjectHeader from '../containers/ProjectHeader';
 
 class App extends React.Component {
   componentWillMount() {

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -30,7 +30,7 @@ import AboutGenizaAr from './about/about-geniza-ar';
 import AboutGenizaEn from './about/about-geniza-en';
 import AboutGenizaHe from './about/about-geniza-he';
 
-const Home = ({ currentLanguage, dispatch, history, language, rtl, translate }) => {
+const Home = ({ adminMode, currentLanguage, dispatch, history, language, rtl, translate }) => {
   const selectWorkflow = (workflow) => {
     dispatch(fetchWorkflow(workflow)).then(()=>{
       return dispatch(fetchSubject());
@@ -92,8 +92,10 @@ const Home = ({ currentLanguage, dispatch, history, language, rtl, translate }) 
             <div className="home-page__buttons">
               <div>
                 <button
-                  className="button button__dark-disabled"
-                  disabled
+                  className={classnames('button', {
+                    'button__dark-disabled': !adminMode
+                  })}
+                  disabled={!adminMode}
                   onClick={selectWorkflow.bind(null, config.easyHebrew)}
                 >
                   {translate('transcribeHebrew.easy')}
@@ -102,8 +104,10 @@ const Home = ({ currentLanguage, dispatch, history, language, rtl, translate }) 
               </div>
               <div>
                 <button
-                  className="button button__dark-disabled"
-                  disabled
+                  className={classnames('button', {
+                    'button__dark-disabled': !adminMode
+                  })}
+                  disabled={!adminMode}
                   onClick={selectWorkflow.bind(null, config.challengingHebrew)}
                 >
                   {translate('transcribeHebrew.challenging')}
@@ -116,8 +120,11 @@ const Home = ({ currentLanguage, dispatch, history, language, rtl, translate }) 
             <div className="home-page__buttons">
               <div>
                 <a
-                  className="button button__dark-disabled"
-                  // href={`${classifyPath}${c.hebrewKeyword}`}
+                  className={classnames('button', {
+                    'button__dark-disabled': !adminMode
+                  })}
+                  href={`${classifyPath}${c.hebrewKeyword}`}
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   {translate('keywordsHebrew.button')} <i className="fa fa-external-link-alt" />
@@ -130,6 +137,7 @@ const Home = ({ currentLanguage, dispatch, history, language, rtl, translate }) 
               <a
                 className="button"
                 href={`${classifyPath}${c.phaseOne}`}
+                rel="noopener noreferrer"
                 target="_blank"
               >
                 {translate('classifyFragments.button')} <i className="fa fa-external-link-alt" />
@@ -146,8 +154,10 @@ const Home = ({ currentLanguage, dispatch, history, language, rtl, translate }) 
             <div className="home-page__buttons">
               <div>
                 <button
-                  className="button button__dark-disabled"
-                  disabled
+                  className={classnames('button', {
+                    'button__dark-disabled': !adminMode
+                  })}
+                  disabled={!adminMode}
                   onClick={selectWorkflow.bind(null, config.easyArabic)}
                 >
                   {translate('transcribeArabic.easy')}
@@ -156,8 +166,10 @@ const Home = ({ currentLanguage, dispatch, history, language, rtl, translate }) 
               </div>
               <div>
                 <button
-                  className="button button__dark-disabled"
-                  disabled
+                  className={classnames('button', {
+                    'button__dark-disabled': !adminMode
+                  })}
+                  disabled={!adminMode}
                   onClick={selectWorkflow.bind(null, config.challengingArabic)}
                 >
                   {translate('transcribeArabic.challenging')}
@@ -170,8 +182,11 @@ const Home = ({ currentLanguage, dispatch, history, language, rtl, translate }) 
             <div className="home-page__buttons">
               <div>
                 <a
-                  className="button button__dark-disabled"
-                  // href={`${classifyPath}${c.arabicKeyword}`}
+                  className={classnames('button', {
+                    'button__dark-disabled': !adminMode
+                  })}
+                  href={`${classifyPath}${c.arabicKeyword}`}
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   {translate('keywordsArabic.button')} <i className="fa fa-external-link-alt" />
@@ -234,6 +249,7 @@ const Home = ({ currentLanguage, dispatch, history, language, rtl, translate }) 
 };
 
 Home.propTypes = {
+  adminMode: PropTypes.bool,
   currentLanguage: PropTypes.string.isRequired,
   dispatch: PropTypes.func,
   history: PropTypes.shape({
@@ -245,6 +261,7 @@ Home.propTypes = {
 };
 
 Home.defaultProps = {
+  adminMode: false,
   dispatch: () => {},
   history: null,
   rtl: false,
@@ -252,6 +269,7 @@ Home.defaultProps = {
 };
 
 const mapStateToProps = state => ({
+  adminMode: state.login.adminMode,
   currentLanguage: getActiveLanguage(state.locale).code,
   language: state.languages.language,
   rtl: state.languages.rtl,

--- a/src/components/WorkflowSelection.jsx
+++ b/src/components/WorkflowSelection.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
+import classnames from 'classnames';
 import { getTranslate, getActiveLanguage } from 'react-localize-redux';
 import { fetchWorkflow, toggleSelection } from '../ducks/workflow';
 import { fetchSubject } from '../ducks/subject';
@@ -10,7 +11,7 @@ import { togglePopup } from '../ducks/dialog';
 import { config } from '../config';
 import StartNewWorkConfirmation from './StartNewWorkConfirmation';
 
-const WorkflowSelection = ({ className, dispatch, location, history, translate, showAllWorkflows, activeAnnotationExists }) => {
+const WorkflowSelection = ({ adminMode, className, dispatch, location, history, translate, showAllWorkflows, activeAnnotationExists }) => {
   const proceedToClassifier = () => {
     dispatch(toggleSelection(false));
     dispatch(togglePopup(null));
@@ -71,6 +72,7 @@ const WorkflowSelection = ({ className, dispatch, location, history, translate, 
             <a
               className="tertiary-label"
               href={`${classifyPath}${c.phaseOne}`}
+              rel="noopener noreferrer"
               target="_blank"
             >
               {translate('workflowSelection.phaseOne')} <i className="fa fa-external-link-alt" />
@@ -82,7 +84,7 @@ const WorkflowSelection = ({ className, dispatch, location, history, translate, 
             <div className="disabled-workflow">
               <button
                 className="tertiary-label"
-                disabled
+                disabled={!adminMode}
                 onClick={selectWorkflow.bind(null, c.easyHebrew)}
               >
                 {translate('transcribeHebrew.easy')}
@@ -92,7 +94,7 @@ const WorkflowSelection = ({ className, dispatch, location, history, translate, 
             <div className="disabled-workflow">
               <button
                 className="tertiary-label disabled-workflow"
-                disabled
+                disabled={!adminMode}
                 onClick={selectWorkflow.bind(null, c.challengingHebrew)}
               >
                 {translate('transcribeHebrew.challenging')}
@@ -104,10 +106,12 @@ const WorkflowSelection = ({ className, dispatch, location, history, translate, 
               <span className="primary-label">{translate('workflowSelection.keywordSearch')}</span>
               <div className="disabled-workflow">
                 <a
-                  className="tertiary-label"
-                  data-disabled-href={`${classifyPath}${c.hebrewKeyword}`}
-                  data-disabled-target="_blank"
-                  href="#"                  
+                  className={classnames('tertiary-label', {
+                    'disabled-workflow--enable': adminMode
+                  })}
+                  href={`${classifyPath}${c.hebrewKeyword}`}
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
                   {translate('keywordsHebrew.button')} <i className="fa fa-external-link-alt" />
                 </a>
@@ -121,7 +125,7 @@ const WorkflowSelection = ({ className, dispatch, location, history, translate, 
             <div className="disabled-workflow">
               <button
                 className="tertiary-label"
-                disabled
+                disabled={!adminMode}
                 onClick={selectWorkflow.bind(null, c.easyArabic)}
               >
                 {translate('transcribeArabic.easy')}
@@ -131,7 +135,7 @@ const WorkflowSelection = ({ className, dispatch, location, history, translate, 
             <div className="disabled-workflow">
               <button
                 className="tertiary-label"
-                disabled
+                disabled={!adminMode}
                 onClick={selectWorkflow.bind(null, c.challengingArabic)}
               >
                 {translate('transcribeArabic.challenging')}
@@ -143,10 +147,12 @@ const WorkflowSelection = ({ className, dispatch, location, history, translate, 
               <span className="primary-label">{translate('workflowSelection.keywordSearch')}</span>
               <div className="disabled-workflow">
                 <a
-                  className="tertiary-label"
-                  data-disabled-href={`${classifyPath}${c.arabicKeyword}`}
-                  data-disabled-target="_blank"
-                  href="#"
+                  className={classnames('tertiary-label', {
+                    'disabled-workflow--enable': adminMode
+                  })}
+                  href={`${classifyPath}${c.arabicKeyword}`}
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
                   {translate('keywordsArabic.button')} <i className="fa fa-external-link-alt" />
                 </a>
@@ -162,6 +168,7 @@ const WorkflowSelection = ({ className, dispatch, location, history, translate, 
 
 WorkflowSelection.propTypes = {
   activeAnnotationExists: PropTypes.bool,
+  adminMode: PropTypes.bool,
   className: PropTypes.string,
   dispatch: PropTypes.func.isRequired,
   history: PropTypes.shape({
@@ -176,6 +183,7 @@ WorkflowSelection.propTypes = {
 
 WorkflowSelection.defaultProps = {
   activeAnnotationExists: false,
+  adminMode: false,
   className: '',
   dispatch: () => {},
   history: {
@@ -198,6 +206,7 @@ const mapStateToProps = state => {
     //We need to know if the user has any work that can be retrieved (either
     //from the Redux store of local storage) so we can prompt them to continue.
     activeAnnotationExists: (!!state.workflow.data && !!state.subject.currentSubject) || userHasWorkInProgress,
+    adminMode: state.login.adminMode,
     currentLanguage: getActiveLanguage(state.locale).code,
     translate: getTranslate(state.locale),
     user: state.login.user,  //Needed, otherwise component won't update when it detects a user login.

--- a/src/containers/ProjectHeader.jsx
+++ b/src/containers/ProjectHeader.jsx
@@ -6,9 +6,11 @@ import { connect } from 'react-redux';
 import { getTranslate, getActiveLanguage } from 'react-localize-redux';
 
 import { config } from '../config.js';
-import WorkflowSelection from './WorkflowSelection';
+import AdminToggle from '../components/AdminToggle';
+import WorkflowSelection from '../components/WorkflowSelection';
 
 import { setLanguage, LANGUAGES } from '../ducks/languages';
+import { toggleAdminMode } from '../ducks/login';
 import { toggleSelection } from '../ducks/workflow';
 
 class ProjectHeader extends React.Component {
@@ -16,6 +18,7 @@ class ProjectHeader extends React.Component {
     super();
 
     this.toggleDropdown = this.toggleDropdown.bind(this);
+    this.toggleAdminMode = this.toggleAdminMode.bind(this);
   }
 
   componentWillReceiveProps(next) {
@@ -30,6 +33,10 @@ class ProjectHeader extends React.Component {
 
   toggleDropdown(e, nextState = !this.props.showWorkflows) {
     this.props.dispatch(toggleSelection(nextState));
+  }
+
+  toggleAdminMode() {
+    this.props.dispatch(toggleAdminMode());
   }
 
   render() {
@@ -113,6 +120,12 @@ class ProjectHeader extends React.Component {
                 ע
               </button>
             </div>
+            {this.props.isAdmin && (
+              <AdminToggle
+                adminMode={this.props.adminMode}
+                toggleAdminMode={this.toggleAdminMode}
+              />
+            )}
           </nav>
         </div>
       </section>
@@ -121,7 +134,9 @@ class ProjectHeader extends React.Component {
 }
 
 ProjectHeader.propTypes = {
+  adminMode: PropTypes.bool,
   dispatch: PropTypes.func,
+  isAdmin: PropTypes.bool,
   language: PropTypes.string,
   location: PropTypes.shape({
     pathname: PropTypes.string
@@ -132,7 +147,9 @@ ProjectHeader.propTypes = {
 };
 
 ProjectHeader.defaultProps = {
+  adminMode: false,
   dispatch: () => {},
+  isAdmin: false,
   language: LANGUAGES.ENGLISH,
   location: {},
   rtl: false,
@@ -141,7 +158,9 @@ ProjectHeader.defaultProps = {
 };
 
 const mapStateToProps = state => ({
+  adminMode: state.login.adminMode,
   currentLanguage: getActiveLanguage(state.locale).code,
+  isAdmin: state.login.isAdmin,
   language: state.languages.language,
   rtl: state.languages.rtl,
   showWorkflows: state.workflow.showSelection,

--- a/src/containers/ProjectHeader.jsx
+++ b/src/containers/ProjectHeader.jsx
@@ -124,6 +124,7 @@ class ProjectHeader extends React.Component {
               <AdminToggle
                 adminMode={this.props.adminMode}
                 toggleAdminMode={this.toggleAdminMode}
+                translate={this.props.translate}
               />
             )}
           </nav>

--- a/src/ducks/login.js
+++ b/src/ducks/login.js
@@ -4,9 +4,11 @@ import { fetchPreferences } from './project';
 // Action Types
 const SET_LOGIN_USER = 'project/user/SET_LOGIN_USER';
 const SET_ADMIN_FLAG = 'SET_ADMIN_FLAG';
+const TOGGLE_ADMIN_MODE = 'TOGGLE_ADMIN_MODE';
 
 // Reducer
 const initialState = {
+  adminMode: false,
   initialised: false,
   isAdmin: false,
   user: null
@@ -25,6 +27,11 @@ const loginReducer = (state = initialState, action) => {
         isAdmin: action.isAdmin
       });
 
+    case TOGGLE_ADMIN_MODE:
+      return Object.assign({}, state, {
+        adminMode: action.adminMode
+      });
+
     default:
       return state;
   }
@@ -35,19 +42,17 @@ const isProjectAdmin = (user) => {
   return (dispatch, getState) => {
     const ACCEPTED_ROLES = ['owner', 'collaborator', 'expert', 'researcher', 'translator'];
     const project = getState().project.data;
-    let isAdmin = false;
     if (project && user) {
       project.get('project_roles', { user_id: user.id })
         .then(([projectRoles]) => {
           if (projectRoles.roles) {
-            isAdmin = projectRoles.roles.some(role => ACCEPTED_ROLES.indexOf(role) >= 0);
+            const isAdmin = projectRoles.roles.some(role => ACCEPTED_ROLES.indexOf(role) >= 0);
+            dispatch({ type: SET_ADMIN_FLAG, isAdmin });
           }
         });
+    } else {
+      dispatch({ type: SET_ADMIN_FLAG, isAdmin: false });
     }
-    dispatch({
-      type: SET_ADMIN_FLAG,
-      isAdmin
-    });
   };
 };
 
@@ -86,6 +91,16 @@ const logoutFromPanoptes = () => {
   };
 };
 
+const toggleAdminMode = () => {
+  return (dispatch, getState) => {
+    const adminMode = !getState().login.adminMode;
+    dispatch({
+      type: TOGGLE_ADMIN_MODE,
+      adminMode
+    });
+  };
+};
+
 // Helper functions
 const computeRedirectURL = (window) => {
   const { location } = window;
@@ -99,5 +114,6 @@ export {
   checkLoginUser,
   loginToPanoptes,
   logoutFromPanoptes,
-  setLoginUser
+  setLoginUser,
+  toggleAdminMode
 };

--- a/src/locales/ar.js
+++ b/src/locales/ar.js
@@ -80,6 +80,7 @@ export default {
     resumeWorkInProgress: 'Resume Work'
   },
   general: {
+    admin: 'Admin',
     hebrew: 'عبري',
     arabic: 'عربي',
     comingSoon: 'Coming Soon!'

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -41,6 +41,7 @@ export default {
     resumeWorkInProgress: 'Resume Work'
   },
   general: {
+    admin: 'Admin',
     hebrew: 'Hebrew',
     arabic: 'Arabic',
     comingSoon: 'Coming Soon!'

--- a/src/locales/he.js
+++ b/src/locales/he.js
@@ -41,6 +41,7 @@ export default {
     resumeWorkInProgress: 'Resume Work'
   },
   general: {
+    admin: 'Admin',
     hebrew: 'עברית',
     arabic: 'ערבית',
     comingSoon: 'Coming Soon!'

--- a/src/styles/components/admin-toggle.styl
+++ b/src/styles/components/admin-toggle.styl
@@ -1,0 +1,7 @@
+.admin-toggle
+  align-items: center
+  display: flex
+  padding: 0.5rem
+
+  span
+    margin: 0.25rem

--- a/src/styles/components/home-page.styl
+++ b/src/styles/components/home-page.styl
@@ -123,6 +123,7 @@
         display: block
 
         &.button__dark-disabled
+          color: white
           cursor: default
           pointer-events: none
 

--- a/src/styles/components/home-page.styl
+++ b/src/styles/components/home-page.styl
@@ -119,8 +119,12 @@
         padding: 0
 
       a
-        color: white
+        color: $plum
         display: block
+
+        &.button__dark-disabled
+          cursor: default
+          pointer-events: none
 
     .body-font
       color: $warning

--- a/src/styles/global/buttons.styl
+++ b/src/styles/global/buttons.styl
@@ -29,9 +29,10 @@
 .disabled-workflow
   margin-top: 0 !important
 
-  button, a
-    cursor: default !important
+  button:disabled, a:not(.disabled-workflow--enable)
+    cursor: default
     opacity: 0.5
+    pointer-events: none
 
     &:hover, &:focus
       background: none !important


### PR DESCRIPTION
closes #103 

This PR adds admin functionality, which consists of:
- Checking if logged-in user is an admin ('owner', 'collaborator', 'expert', 'researcher', 'translator')
- If so, display an Admin checkbox on the project header to toggle admin mode
- If admin mode is on, disabled workflows are enabled

ProjectHeader is also moved into the containers folder, as it seems more appropriate and a bit more organization is helpful in this repo.