### PR TITLE
Improve Transcription popup (SelectedAnnotation component) position

### DIFF
--- a/src/components/Dialog.jsx
+++ b/src/components/Dialog.jsx
@@ -50,7 +50,6 @@ class Dialog extends React.Component {
       this.props.default  //Optionally, override the center-of-screen default position with whatever we want.
     );
     
-    console.log('+++ defaultPosition: ', defaultPosition, this.props.default);
     const children = React.Children.map(this.props.children, (child) => {
       return React.cloneElement(child, { updateSize: this.updateSize });
     });

--- a/src/components/Dialog.jsx
+++ b/src/components/Dialog.jsx
@@ -45,7 +45,12 @@ class Dialog extends React.Component {
     const x = (window.innerWidth / 2) - (width / 2);
     const y = ((window.innerHeight / 2) - (height / 2)) + window.pageYOffset;
 
-    const defaultPosition = { x, y, height, width };
+    const defaultPosition = Object.assign({},
+      { x, y, height, width },
+      this.props.default  //Optionally, override the center-of-screen default position with whatever we want.
+    );
+    
+    console.log('+++ defaultPosition: ', defaultPosition, this.props.default);
     const children = React.Children.map(this.props.children, (child) => {
       return React.cloneElement(child, { updateSize: this.updateSize });
     });
@@ -86,6 +91,7 @@ class Dialog extends React.Component {
 
 Dialog.defaultProps = {
   component: '',
+  default: undefined,
   dispatch: () => {},
   focusedDialog: '',
   isAnnotation: true,
@@ -96,6 +102,7 @@ Dialog.defaultProps = {
 Dialog.propTypes = {
   children: PropTypes.node,
   component: PropTypes.string,
+  default: PropTypes.object,
   dispatch: PropTypes.func,
   focusedDialog: PropTypes.string,
   isAnnotation: PropTypes.bool,

--- a/src/components/WorkflowSelection.jsx
+++ b/src/components/WorkflowSelection.jsx
@@ -198,7 +198,7 @@ WorkflowSelection.defaultProps = {
 const mapStateToProps = state => {
   const user = state.login.user;
   const userHasWorkInProgress = user && WorkInProgress.check(user);
-
+  
   return {
     //Does the user currently have a page being actively annotated, (e.g. user
     //navigated away from the Classifier page and wants to return), or have
@@ -206,7 +206,9 @@ const mapStateToProps = state => {
     //We need to know if the user has any work that can be retrieved (either
     //from the Redux store of local storage) so we can prompt them to continue.
     activeAnnotationExists: (!!state.workflow.data && !!state.subject.currentSubject) || userHasWorkInProgress,
-    adminMode: state.login.adminMode,
+    adminMode: (!/^http:\/\/localhost:3000\//i.test(window.location.href))  //TEMP
+      ? state.login.adminMode
+      : true,
     currentLanguage: getActiveLanguage(state.locale).code,
     translate: getTranslate(state.locale),
     user: state.login.user,  //Needed, otherwise component won't update when it detects a user login.

--- a/src/components/WorkflowSelection.jsx
+++ b/src/components/WorkflowSelection.jsx
@@ -206,7 +206,7 @@ const mapStateToProps = state => {
     //We need to know if the user has any work that can be retrieved (either
     //from the Redux store of local storage) so we can prompt them to continue.
     activeAnnotationExists: (!!state.workflow.data && !!state.subject.currentSubject) || userHasWorkInProgress,
-    adminMode: false,
+    adminMode: state.login.adminMode,
     currentLanguage: getActiveLanguage(state.locale).code,
     translate: getTranslate(state.locale),
     user: state.login.user,  //Needed, otherwise component won't update when it detects a user login.

--- a/src/components/WorkflowSelection.jsx
+++ b/src/components/WorkflowSelection.jsx
@@ -206,9 +206,7 @@ const mapStateToProps = state => {
     //We need to know if the user has any work that can be retrieved (either
     //from the Redux store of local storage) so we can prompt them to continue.
     activeAnnotationExists: (!!state.workflow.data && !!state.subject.currentSubject) || userHasWorkInProgress,
-    adminMode: (!/^http:\/\/localhost:3000\//i.test(window.location.href))  //TEMP
-      ? state.login.adminMode
-      : true,
+    adminMode: false,
     currentLanguage: getActiveLanguage(state.locale).code,
     translate: getTranslate(state.locale),
     user: state.login.user,  //Needed, otherwise component won't update when it detects a user login.

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -36,8 +36,6 @@ class ClassifierContainer extends React.Component {
       ? this.props.annotationPaneOffset
       : undefined;
     
-    console.log('+++ render ClassifierContainer: ', annotationPaneDefault);
-    
     return (
       <main className="classifier">
         <ControlPanel />

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -32,6 +32,12 @@ class ClassifierContainer extends React.Component {
   }
 
   render() {
+    const annotationPaneDefault = (this.props.annotationPaneOffset)
+      ? this.props.annotationPaneOffset
+      : undefined;
+    
+    console.log('+++ render ClassifierContainer: ', annotationPaneDefault);
+    
     return (
       <main className="classifier">
         <ControlPanel />
@@ -39,7 +45,7 @@ class ClassifierContainer extends React.Component {
         <Toolbar />
 
         {(this.props.annotationPane === null) ? null :
-          <Dialog component={this.props.component} size={this.props.annotationPaneSize}>
+          <Dialog component={this.props.component} size={this.props.annotationPaneSize} default={annotationPaneDefault}>
             {this.props.annotationPane}
           </Dialog>
         }
@@ -87,6 +93,7 @@ ClassifierContainer.defaultProps = {
 const mapStateToProps = state => ({
   annotationPane: state.dialog.annotationPane,
   annotationPaneSize: state.dialog.annotationPaneSize,
+  annotationPaneOffset: state.dialog.annotationPaneOffset,
   component: state.dialog.component,
   dialog: state.dialog.data,
   popup: state.dialog.popup,

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -316,7 +316,7 @@ class SubjectViewer extends React.Component {
     }
     //--------
     console.log('+++ offset B: ', selectedAnnotation);
-    this.props.dispatch(toggleAnnotation(<SelectedAnnotation />, selAnno));
+    this.props.dispatch(toggleAnnotation(<SelectedAnnotation />, dimensions, offset));
   }
 
   render() {

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -224,7 +224,11 @@ class SubjectViewer extends React.Component {
       if (this.props.annotationInProgress && this.props.annotationInProgress.points &&
           this.props.annotationInProgress.points.length > 1) {
         const dimensions = this.props.showKeyboard ? ANNOTATION_BOX_DIMENSIONS : ANNOTATION_BOX_NO_KEYBOARD_DIMENSIONS;
-        this.props.dispatch(toggleAnnotation(<SelectedAnnotation />, dimensions));
+        const offset = {
+          y: 0
+        };
+        console.log('+++ offset A: ', offset);
+        this.props.dispatch(toggleAnnotation(<SelectedAnnotation />, dimensions, offset));
         this.props.dispatch(completeAnnotation());
       }
     } else if (this.props.viewerState === SUBJECTVIEWER_STATE.CROPPING) {
@@ -272,7 +276,11 @@ class SubjectViewer extends React.Component {
   onSelectAnnotation(indexOfAnnotation) {
     this.props.dispatch(selectAnnotation(indexOfAnnotation));
     const dimensions = this.props.showKeyboard ? ANNOTATION_BOX_DIMENSIONS : ANNOTATION_BOX_NO_KEYBOARD_DIMENSIONS;
-    this.props.dispatch(toggleAnnotation(<SelectedAnnotation />, dimensions));
+    const offset = {
+      y: 0
+    };
+    console.log('+++ offset B: ', offset);
+    this.props.dispatch(toggleAnnotation(<SelectedAnnotation />, dimensions, offset));
   }
 
   render() {

--- a/src/ducks/dialog.js
+++ b/src/ducks/dialog.js
@@ -3,6 +3,7 @@ const DEFAULT_SIZE = { height: 450, width: 600 };
 const initialState = {
   annotationPane: null,
   annotationPaneSize: DEFAULT_SIZE,
+  annotationPaneOffset: null,
   data: null,
   focus: null,
   isPrompt: false,
@@ -35,7 +36,8 @@ const dialogReducer = (state = initialState, action) => {
     case SET_ANNOTATION_PANE:
       return Object.assign({}, state, {
         annotationPane: action.dialog,
-        annotationPaneSize: action.annotationPaneSize
+        annotationPaneSize: action.annotationPaneSize,
+        annotationPaneOffset: action.annotationPaneOffset
       });
 
     case SET_FOCUS:
@@ -69,12 +71,13 @@ const togglePopup = (popup) => {
   };
 };
 
-const toggleAnnotation = (dialog, annotationPaneSize = DEFAULT_SIZE) => {
+const toggleAnnotation = (dialog, annotationPaneSize = DEFAULT_SIZE, annotationPaneOffset = null) => {
   return (dispatch) => {
     dispatch({
       type: SET_ANNOTATION_PANE,
       dialog,
-      annotationPaneSize
+      annotationPaneSize,
+      annotationPaneOffset
     });
   };
 };


### PR DESCRIPTION
## PR Overview
This PR improves the position of the transcription popup (i.e. the SelectedAnnotation component).

When the transcription popup _pops up,_ (i.e. after creating a new Annotation or clicking on an existing one) the position of the popup should NOT obscure the annotation marks, and should appear below (vertically beneath) them.

![screen shot 2018-06-14 at 18 29 43](https://user-images.githubusercontent.com/13952701/41428110-fe08b23c-7000-11e8-9674-ea233c6ce1f6.png)

_The transcription popup appearing vertically below the annotation marks. This allows readers to read the line of text they just marked._

### Status
WIP

Currently:
- `<Dialog>` component now accepts a "default x-y offset" as an optional argument. This allows us to position the Dialog (hence, the SelectedAnnotation component) in a way that's _not_ centred on the window.
- `SubjectViewer.figureOutActualXYOfAPointInTheImage()` calculates the actual x-y coordinates (i.e. relative to the window) of a point on the image (i.e. the point has coordinates relative to the rotated/scaled/panned image)

Next:
- Now that we know the x-y coordinates of the start/end points of an annotation, we need to calculate a decent y-offset for the transcription popup window.