### PR TITLE
Show Start and Begin Mark Reminders

### DIFF
--- a/src/components/HelperMessage.jsx
+++ b/src/components/HelperMessage.jsx
@@ -20,7 +20,7 @@ class HelperMessage extends React.Component {
     const y = this.props.viewerSize.height * QUARTER_OF_PAGE;
 
     return (
-      <g className="block-transcription" style={{ direction: 'ltr' }}>
+      <g className="helper-message" style={{ direction: 'ltr' }}>
         <rect
           x={-(this.props.width / 2)}
           y={y}
@@ -45,15 +45,14 @@ class HelperMessage extends React.Component {
         <text
           x={(this.props.width / 2) - 18}
           y={y + 20}
-          className="close-reminder"
-          fontFamily="FontAwesome"
+          className="helper-message__close-button"
           fill="#472B36"
           fontSize="10px"
           fontWeight="700"
           textAnchor="end"
           onClick={this.onClose}
         >
-          &#xf00d;
+          x
         </text>
       </g>
     );

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -215,7 +215,7 @@ const Home = ({ adminMode, currentLanguage, dispatch, history, language, rtl, tr
           <a href="https://www.bodleian.ox.ac.uk/" target="_blank" rel="noopener noreferrer"><img alt="Bodleian" src={ImgBodleian} /></a>
           <img alt="The e-Lijah Lab at the University of Haifa" src={ImgElijah} />
           <a href="http://gniza.haifa.ac.il" target="_blank" rel="noopener noreferrer"><img alt="The Centre for Interdisciplinary Research of the Cairo Genizah at the University of Haifa" src={GenizahCentre} /></a>
-          
+
           <a href="https://www.imls.gov/" target="_blank" rel="noopener noreferrer"><img alt="IMLS" src={ImgIMLS} /></a>
         </div>
       </div>

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -4,13 +4,15 @@ import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { getTranslate, getActiveLanguage } from 'react-localize-redux';
 
-import CollectionsContainer from '../containers/CollectionsContainer';
 import { toggleHints } from '../ducks/aggregations';
 import { toggleDialog } from '../ducks/dialog';
-import { toggleReminder } from '../ducks/reminder';
+import { shownStartReminder, toggleReminder } from '../ducks/reminder';
 import { toggleFavorite } from '../ducks/subject';
-import { shownStartReminder, toggleMarks } from '../ducks/subject-viewer';
+import { toggleMarks } from '../ducks/subject-viewer';
+
+import CollectionsContainer from '../containers/CollectionsContainer';
 import FavoritesButton from './FavoritesButton';
+import HelperMessage from './HelperMessage';
 
 import { setScaling, resetView,
   setRotation, toggleContrast,
@@ -67,11 +69,14 @@ class Toolbar extends React.Component {
   }
 
   useAnnotationTool() {
-    if (!this.props.shownReminder) {
+    if (!this.props.shownBeginReminder) {
       this.props.dispatch(shownStartReminder());
     }
     if (this.props.reminder) {
       this.props.dispatch(toggleReminder(null));
+    }
+    if (!this.props.shownMarkReminder) {
+      setTimeout(() => { this.toggleHelp(); }, 5000);
     }
     this.props.dispatch(setViewerState(SUBJECTVIEWER_STATE.ANNOTATING));
   }
@@ -120,6 +125,15 @@ class Toolbar extends React.Component {
 
   closeDialog() {
     this.props.dispatch(toggleDialog(null));
+  }
+
+  toggleHelp() {
+    if (!this.props.shownMarkReminder) {
+      const message = 'Click at the start and end of a line of text to add a transcription (remember to start on the right side!)';
+      this.props.dispatch(toggleReminder(
+        <HelperMessage message={message} width={565} />
+      ));
+    }
   }
 
   render() {
@@ -222,7 +236,8 @@ Toolbar.propTypes = {
   scaling: PropTypes.number,
   showHints: PropTypes.bool,
   showMarks: PropTypes.bool,
-  shownReminder: PropTypes.bool,
+  shownBeginReminder: PropTypes.bool,
+  shownMarkReminder: PropTypes.bool,
   translate: PropTypes.func,
   user: PropTypes.shape({
     id: PropTypes.string
@@ -240,7 +255,8 @@ Toolbar.defaultProps = {
   scaling: 0,
   showHints: true,
   showMarks: true,
-  shownReminder: false,
+  shownBeginReminder: false,
+  shownMarkReminder: false,
   translate: () => {},
   user: null,
   viewerState: SUBJECTVIEWER_STATE.NAVIGATING
@@ -259,7 +275,8 @@ const mapStateToProps = (state) => {
     scaling: sv.scaling,
     showHints: state.aggregations.showHints,
     showMarks: sv.showMarks,
-    shownReminder: sv.shownReminder,
+    shownBeginReminder: state.reminder.shownBeginReminder,
+    shownMarkReminder: state.reminder.shownMarkReminder,
     translate: getTranslate(state.locale),
     user: state.login.user,
     viewerState: sv.viewerState

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -5,10 +5,11 @@ import classnames from 'classnames';
 import { getTranslate, getActiveLanguage } from 'react-localize-redux';
 
 import CollectionsContainer from '../containers/CollectionsContainer';
-import { toggleDialog } from '../ducks/dialog';
-import { toggleFavorite } from '../ducks/subject';
 import { toggleHints } from '../ducks/aggregations';
-import { toggleMarks } from '../ducks/subject-viewer';
+import { toggleDialog } from '../ducks/dialog';
+import { toggleReminder } from '../ducks/reminder';
+import { toggleFavorite } from '../ducks/subject';
+import { shownStartReminder, toggleMarks } from '../ducks/subject-viewer';
 import FavoritesButton from './FavoritesButton';
 
 import { setScaling, resetView,
@@ -66,6 +67,12 @@ class Toolbar extends React.Component {
   }
 
   useAnnotationTool() {
+    if (!this.props.shownReminder) {
+      this.props.dispatch(shownStartReminder());
+    }
+    if (this.props.reminder) {
+      this.props.dispatch(toggleReminder(null));
+    }
     this.props.dispatch(setViewerState(SUBJECTVIEWER_STATE.ANNOTATING));
   }
 
@@ -84,7 +91,7 @@ class Toolbar extends React.Component {
   toggleShowHints() {
     this.props.dispatch(toggleHints());
   }
-  
+
   toggleShowMarks() {
     this.props.dispatch(toggleMarks());
   }
@@ -124,7 +131,7 @@ class Toolbar extends React.Component {
     const marksIcon = this.props.showMarks ? 'fas fa-comment-dots' : 'fas fa-comment-slash';
     const marksText = this.props.showMarks ? this.props.translate('toolbar.showingMarks')
       : this.props.translate('toolbar.hidingMarks');
-    
+
 
     return (
       <section className={toolbarClass}>
@@ -165,12 +172,12 @@ class Toolbar extends React.Component {
           <i className="fa fa-adjust" />
           {expanded && (<span>{this.props.translate('toolbar.invertColors')}</span>)}
         </button>
-        
+
         <button onClick={this.toggleShowMarks}>
           <i className={marksIcon} />
           {expanded && (<span>{marksText}</span>)}
         </button>
-        
+
         {this.props.aggregations && Object.keys(this.props.aggregations).length ? (
           <button onClick={this.toggleShowHints}>
             <i className={hintsIcon} />
@@ -209,11 +216,13 @@ Toolbar.propTypes = {
   aggregations: PropTypes.object,
   dispatch: PropTypes.func,
   favoriteSubject: PropTypes.bool,
+  reminder: PropTypes.node,
   rotation: PropTypes.number,
   rtl: PropTypes.bool,
   scaling: PropTypes.number,
   showHints: PropTypes.bool,
   showMarks: PropTypes.bool,
+  shownReminder: PropTypes.bool,
   translate: PropTypes.func,
   user: PropTypes.shape({
     id: PropTypes.string
@@ -225,11 +234,13 @@ Toolbar.defaultProps = {
   aggregations: null,
   dispatch: () => {},
   favoriteSubject: false,
+  reminder: null,
   rotation: 0,
   rtl: false,
   scaling: 0,
   showHints: true,
   showMarks: true,
+  shownReminder: false,
   translate: () => {},
   user: null,
   viewerState: SUBJECTVIEWER_STATE.NAVIGATING
@@ -242,11 +253,13 @@ const mapStateToProps = (state) => {
     aggStatus: state.aggregations.status,
     currentLanguage: getActiveLanguage(state.locale).code,
     favoriteSubject: state.subject.favorite,
+    reminder: state.reminder.node,
     rotation: sv.rotation,
     rtl: state.languages.rtl,
     scaling: sv.scaling,
     showHints: state.aggregations.showHints,
     showMarks: sv.showMarks,
+    shownReminder: sv.shownReminder,
     translate: getTranslate(state.locale),
     user: state.login.user,
     viewerState: sv.viewerState

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -26,7 +26,7 @@ class ClassifierContainer extends React.Component {
   componentWillReceiveProps(next) {
     if (this.props.workflowStatus !== next.workflowStatus) {
       this.props.dispatch(togglePopup(null));
-      setTimeout(() => { this.toggleHelp(); }, 4000);
+      setTimeout(() => { this.toggleHelp(); }, 5000);
     }
   }
 
@@ -41,7 +41,7 @@ class ClassifierContainer extends React.Component {
       const message = 'Get Started by clicking "Add Transcription"';
       this.props.dispatch(shownStartReminder());
       this.props.dispatch(toggleReminder(
-        <HelperMessage message={message} width={400} />
+        <HelperMessage message={message} width={275} />
       ));
     }
   }

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { togglePopup } from '../ducks/dialog';
-import { toggleReminder } from '../ducks/reminder';
-import { shownStartReminder } from '../ducks/subject-viewer';
+import { shownStartReminder, toggleReminder } from '../ducks/reminder';
 import { WORKFLOW_STATUS } from '../ducks/workflow';
 import { WorkInProgress } from '../ducks/work-in-progress';
 
@@ -37,7 +36,7 @@ class ClassifierContainer extends React.Component {
   }
 
   toggleHelp() {
-    if (!this.props.shownReminder) {
+    if (!this.props.shownBeginReminder) {
       const message = 'Get Started by clicking "Add Transcription"';
       this.props.dispatch(shownStartReminder());
       this.props.dispatch(toggleReminder(
@@ -83,7 +82,7 @@ ClassifierContainer.propTypes = {
     height: PropTypes.number,
     width: PropTypes.number
   }),
-  shownReminder: PropTypes.bool,
+  shownBeginReminder: PropTypes.bool,
   user: PropTypes.shape({
     id: PropTypes.string
   }),
@@ -97,7 +96,7 @@ ClassifierContainer.defaultProps = {
   dialog: null,
   popup: null,
   size: { height: 200, width: 200 },
-  shownReminder: false,
+  shownBeginReminder: false,
   user: null
 };
 
@@ -108,7 +107,7 @@ const mapStateToProps = state => ({
   dialog: state.dialog.data,
   popup: state.dialog.popup,
   size: state.dialog.size,
-  shownReminder: state.subjectViewer.shownReminder,
+  shownBeginReminder: state.reminder.shownBeginReminder,
   subjectStatus: state.subject.status,
   user: state.login.user,
   workflowStatus: state.workflow.status

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -3,14 +3,18 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { togglePopup } from '../ducks/dialog';
+import { toggleReminder } from '../ducks/reminder';
+import { shownStartReminder } from '../ducks/subject-viewer';
 import { WORKFLOW_STATUS } from '../ducks/workflow';
 import { WorkInProgress } from '../ducks/work-in-progress';
 
 import ControlPanel from '../components/ControlPanel';
 import WorkflowPrompt from '../components/WorkflowPrompt';
 import Toolbar from '../components/Toolbar';
-import SubjectViewer from './SubjectViewer';
 import Dialog from '../components/Dialog';
+import HelperMessage from '../components/HelperMessage';
+
+import SubjectViewer from './SubjectViewer';
 
 class ClassifierContainer extends React.Component {
   componentDidMount() {
@@ -22,12 +26,23 @@ class ClassifierContainer extends React.Component {
   componentWillReceiveProps(next) {
     if (this.props.workflowStatus !== next.workflowStatus) {
       this.props.dispatch(togglePopup(null));
+      setTimeout(() => { this.toggleHelp(); }, 4000);
     }
   }
 
   componentWillUnmount() {
     if (this.props.popup) {
       this.props.dispatch(togglePopup(null));
+    }
+  }
+
+  toggleHelp() {
+    if (!this.props.shownReminder) {
+      const message = 'Get Started by clicking "Add Transcription"';
+      this.props.dispatch(shownStartReminder());
+      this.props.dispatch(toggleReminder(
+        <HelperMessage message={message} width={400} />
+      ));
     }
   }
 
@@ -68,6 +83,7 @@ ClassifierContainer.propTypes = {
     height: PropTypes.number,
     width: PropTypes.number
   }),
+  shownReminder: PropTypes.bool,
   user: PropTypes.shape({
     id: PropTypes.string
   }),
@@ -81,6 +97,7 @@ ClassifierContainer.defaultProps = {
   dialog: null,
   popup: null,
   size: { height: 200, width: 200 },
+  shownReminder: false,
   user: null
 };
 
@@ -91,6 +108,7 @@ const mapStateToProps = state => ({
   dialog: state.dialog.data,
   popup: state.dialog.popup,
   size: state.dialog.size,
+  shownReminder: state.subjectViewer.shownReminder,
   subjectStatus: state.subject.status,
   user: state.login.user,
   workflowStatus: state.workflow.status

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -16,6 +16,7 @@ import {
 
 import { addAnnotationPoint, completeAnnotation, selectAnnotation } from '../ducks/annotations';
 import { toggleAnnotation } from '../ducks/dialog';
+import { shownMarkReminder, toggleReminder } from '../ducks/reminder';
 
 import AnnotationsPane from '../components/AnnotationsPane';
 import AggregationsPane from '../components/AggregationsPane';
@@ -215,6 +216,10 @@ class SubjectViewer extends React.Component {
       this.pointer.now = { x: pointerXY.x, y: pointerXY.y };
       this.tmpTransform = false;
     } else if (this.props.viewerState === SUBJECTVIEWER_STATE.ANNOTATING) {
+      if (!this.props.shownMarkReminder) {
+        this.props.dispatch(shownMarkReminder());
+        this.props.dispatch(toggleReminder(null));
+      }
       if (this.props.selectedAnnotation) { return; }
       if (e.target.parentNode.className.baseVal.indexOf('block-transcription') >= 0) {
         return;
@@ -399,6 +404,7 @@ SubjectViewer.propTypes = {
     details: PropTypes.array
   }),
   showKeyboard: PropTypes.bool,
+  shownMarkReminder: PropTypes.bool,
   showMarks: PropTypes.bool,
   subjectStatus: PropTypes.string,
   viewerSize: PropTypes.shape({
@@ -421,6 +427,7 @@ SubjectViewer.defaultProps = {
   scaling: 1,
   selectedAnnotation: null,
   showKeyboard: true,
+  shownMarkReminder: false,
   showMarks: true,
   subjectStatus: '',
   translationX: 0,
@@ -446,6 +453,7 @@ const mapStateToProps = (state) => {
     scaling: sv.scaling,
     selectedAnnotation: state.annotations.selectedAnnotation,
     showKeyboard: state.keyboard.showKeyboard,
+    shownMarkReminder: state.reminder.shownMarkReminder,
     showMarks: state.subjectViewer.showMarks,
     subjectStatus: state.subject.status,
     translationX: sv.translationX,

--- a/src/ducks/reminder.js
+++ b/src/ducks/reminder.js
@@ -1,7 +1,11 @@
 const TOGGLE_REMINDER = 'TOGGLE_REMINDER';
+const TOGGLE_START_REMINDER = 'TOGGLE_START_REMINDER';
+const TOGGLE_MARK_REMINDER = 'TOGGLE_MARK_REMINDER';
 
 const initialState = {
-  node: null
+  node: null,
+  shownBeginReminder: false,
+  shownMarkReminder: false
 };
 
 const reminderReducer = (state = initialState, action) => {
@@ -9,6 +13,16 @@ const reminderReducer = (state = initialState, action) => {
     case TOGGLE_REMINDER:
       return Object.assign({}, state, {
         node: action.node
+      });
+
+    case TOGGLE_START_REMINDER:
+      return Object.assign({}, state, {
+        shownBeginReminder: true
+      });
+
+    case TOGGLE_MARK_REMINDER:
+      return Object.assign({}, state, {
+        shownMarkReminder: true
       });
 
     default:
@@ -25,8 +39,22 @@ const toggleReminder = (node) => {
   };
 };
 
+const shownStartReminder = () => {
+  return (dispatch) => {
+    dispatch({ type: TOGGLE_START_REMINDER });
+  };
+};
+
+const shownMarkReminder = () => {
+  return (dispatch) => {
+    dispatch({ type: TOGGLE_MARK_REMINDER });
+  };
+};
+
 export default reminderReducer;
 
 export {
+  shownMarkReminder,
+  shownStartReminder,
   toggleReminder
 };

--- a/src/ducks/subject-viewer.js
+++ b/src/ducks/subject-viewer.js
@@ -15,7 +15,6 @@ const initialState = {
   rotation: 0,
   scaling: 1,
   showMarks: true,
-  shownReminder: false,
   translationX: 0,
   translationY: 0,
   viewerSize: { width: 0, height: 0 },
@@ -28,7 +27,6 @@ const SET_ROTATION = 'SET_ROTATION';
 const SET_SCALING = 'SET_SCALING';
 const SET_TRANSLATION = 'SET_TRANSLATION';
 const SET_VIEWER_STATE = 'SET_VIEWER_STATE';
-const TOGGLE_START_REMINDER = 'TOGGLE_START_REMINDER';
 const TOGGLE_CONTRAST = 'TOGGLE_CONTRAST';
 const TOGGLE_MARKS = 'TOGGLE_MARKS';
 const UPDATE_IMAGE_SIZE = 'UPDATE_IMAGE_SIZE';
@@ -133,11 +131,6 @@ const subjectViewerReducer = (state = initialState, action) => {
         frame: action.frame
       });
 
-    case TOGGLE_START_REMINDER:
-      return Object.assign({}, state, {
-        shownReminder: true
-      });
-
     default: {
       return state;
     }
@@ -231,12 +224,6 @@ const toggleMarks = () => {
   };
 };
 
-const shownStartReminder = () => {
-  return (dispatch) => {
-    dispatch({ type: TOGGLE_START_REMINDER });
-  };
-};
-
 export default subjectViewerReducer;
 
 export {
@@ -246,7 +233,6 @@ export {
   setScaling,
   setTranslation,
   setViewerState,
-  shownStartReminder,
   toggleContrast,
   toggleMarks,
   updateImageSize,

--- a/src/ducks/subject-viewer.js
+++ b/src/ducks/subject-viewer.js
@@ -15,6 +15,7 @@ const initialState = {
   rotation: 0,
   scaling: 1,
   showMarks: true,
+  shownReminder: false,
   translationX: 0,
   translationY: 0,
   viewerSize: { width: 0, height: 0 },
@@ -27,6 +28,7 @@ const SET_ROTATION = 'SET_ROTATION';
 const SET_SCALING = 'SET_SCALING';
 const SET_TRANSLATION = 'SET_TRANSLATION';
 const SET_VIEWER_STATE = 'SET_VIEWER_STATE';
+const TOGGLE_START_REMINDER = 'TOGGLE_START_REMINDER';
 const TOGGLE_CONTRAST = 'TOGGLE_CONTRAST';
 const TOGGLE_MARKS = 'TOGGLE_MARKS';
 const UPDATE_IMAGE_SIZE = 'UPDATE_IMAGE_SIZE';
@@ -131,6 +133,11 @@ const subjectViewerReducer = (state = initialState, action) => {
         frame: action.frame
       });
 
+    case TOGGLE_START_REMINDER:
+      return Object.assign({}, state, {
+        shownReminder: true
+      });
+
     default: {
       return state;
     }
@@ -224,6 +231,12 @@ const toggleMarks = () => {
   };
 };
 
+const shownStartReminder = () => {
+  return (dispatch) => {
+    dispatch({ type: TOGGLE_START_REMINDER });
+  };
+};
+
 export default subjectViewerReducer;
 
 export {
@@ -233,6 +246,7 @@ export {
   setScaling,
   setTranslation,
   setViewerState,
+  shownStartReminder,
   toggleContrast,
   toggleMarks,
   updateImageSize,

--- a/src/styles/components/helper-message.styl
+++ b/src/styles/components/helper-message.styl
@@ -1,0 +1,5 @@
+.helper-message
+  cursor: default
+
+  &__close-button
+    cursor: pointer


### PR DESCRIPTION
Closes #108 

This PR adds the "Get Started..." reminder as seen on [this](https://projects.invisionapp.com/share/37D8GSEK9#/screens/277573966) design. The component/design already existed, but functionality needed to be added to have it appear on the classifier page after some time of inactivity.

~WIP while the second reminder is added.~