### PR TITLE
Add Help Modals

### DIFF
--- a/src/components/HelpModal.jsx
+++ b/src/components/HelpModal.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const WIDTH = 450;
-const BUFFER = 8;
+const SIDE_BUFFER = 8;
+const TOP_BUFFER = 40;
 
-const TextModifierHelp = ({ helpBox, questionMark, togglePopup }) => {
+const HelpModal = ({ helpBox, questionMark, text, togglePopup }) => {
   const style = {
-    left: (questionMark.offsetLeft - (WIDTH / 2)) + BUFFER,
+    left: (questionMark.offsetLeft - (WIDTH / 2)) + SIDE_BUFFER,
+    top: questionMark.offsetTop + TOP_BUFFER,
     width: WIDTH
   };
 
@@ -23,21 +25,20 @@ const TextModifierHelp = ({ helpBox, questionMark, togglePopup }) => {
       <hr className="plum-line" />
       <div>
         <span className="body-font">
-          Use these text modifiers to indicate special occurrences. Highlight the
-          text and click the applicable modifier. Find examples of each in the
-          Field Guide.
+          {text}
         </span>
       </div>
     </div>
   );
 };
 
-TextModifierHelp.propTypes = {
+HelpModal.propTypes = {
   //helpBox: PropTypes.object.isRequired,  //WARNING: helpBox is a reference to a component, but it's not actually an object. We'll remove this until we can figure out what's wrong here.
   questionMark: PropTypes.shape({
     innerHeight: PropTypes.number
   }).isRequired,
+  text: PropTypes.string.isRequired,
   togglePopup: PropTypes.func.isRequired
 };
 
-export default TextModifierHelp;
+export default HelpModal;

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -19,7 +19,7 @@ import { toggleMarks } from '../ducks/subject-viewer';
 import AnnotationKeyboard from './AnnotationKeyboard';
 import FlippedBtn from './styled/FlippedBtn';
 import QuestionPrompt from './QuestionPrompt';
-import TextModifierHelp from './TextModifierHelp';
+import HelpModal from './HelpModal';
 import { KeyboardOptions } from '../lib/KeyboardTypes';
 import cleanText from '../lib/clean-text';
 import { Utility, KEY_VALUES } from '../lib/Utility';
@@ -50,11 +50,15 @@ class SelectedAnnotation extends React.Component {
     this.toggleMarks = this.toggleMarks.bind(this);
     this.toggleScriptOptions = this.toggleScriptOptions.bind(this);
     this.toggleWhatsThis = this.toggleWhatsThis.bind(this);
+    this.toggleCloseKeyboardHelp = this.toggleCloseKeyboardHelp.bind(this);
+    this.toggleScriptOptionsHelp = this.toggleScriptOptionsHelp.bind(this);
 
     this.state = {
       disableSubmit: true,
-      showHelp: false,
-      showScriptOptions: false
+      showCloseKeyboardHelp: false,
+      showModifierHelp: false,
+      showScriptOptions: false,
+      showScriptOptionsHelp: false
     };
   }
 
@@ -181,12 +185,13 @@ class SelectedAnnotation extends React.Component {
     if ((this.dropdown && this.dropdown.contains(e.target)) || (this.scriptToggle && this.scriptToggle.contains(e.target))) {
       return;
     }
-    if ((this.helpBox && this.helpBox.contains(e.target)) || (this.questionMark && this.questionMark.contains(e.target))) {
+    if ((this.helpBox && this.helpBox.contains(e.target)) || (this.modifierHelpMark && this.modifierHelpMark.contains(e.target))) {
       return;
     }
-    if (this.state.showHelp || this.state.showScriptOptions) {
-      this.setState({ showHelp: false });
-      this.setState({ showScriptOptions: false });
+    if (this.state.showModifierHelp || this.state.showScriptOptions || this.state.showCloseKeyboardHelp || this.state.showScriptOptionsHelp) {
+      this.setState({ showModifierHelp: false });
+      this.setState({ showCloseKeyboardHelp: false });
+      this.setState({ showScriptOptionsHelp: false });
     }
   }
 
@@ -302,7 +307,15 @@ class SelectedAnnotation extends React.Component {
   }
 
   toggleWhatsThis() {
-    this.setState({ showHelp: !this.state.showHelp });
+    this.setState({ showModifierHelp: !this.state.showModifierHelp });
+  }
+
+  toggleCloseKeyboardHelp() {
+    this.setState({ showCloseKeyboardHelp: !this.state.showCloseKeyboardHelp });
+  }
+
+  toggleScriptOptionsHelp() {
+    this.setState({ showScriptOptionsHelp: !this.state.showScriptOptionsHelp });
   }
 
   scriptOption(script, i) {
@@ -366,11 +379,12 @@ class SelectedAnnotation extends React.Component {
           placeholder={translate('transcribeBox.textArea')}
         />
         <div className="selected-annotation__text-modifiers">
-          <button onClick={this.toggleWhatsThis} ref={(c) => { this.questionMark = c; }}><i className="far fa-question-circle" /></button>
-          {this.state.showHelp && (
-            <TextModifierHelp
+          <button onClick={this.toggleWhatsThis} ref={(c) => { this.modifierHelpMark = c; }}><i className="far fa-question-circle" /></button>
+          {this.state.showModifierHelp && (
+            <HelpModal
               helpBox={(c) => { this.helpBox = c; }}
-              questionMark={this.questionMark}
+              questionMark={this.modifierHelpMark}
+              text={translate('helpModals.textModifiers')}
               togglePopup={this.toggleWhatsThis}
             />
           )}
@@ -399,6 +413,16 @@ class SelectedAnnotation extends React.Component {
             </div>
             <div>
               <button className="small-btn" onClick={this.toggleKeyboardView}>{keyboardToggleText}</button>
+
+              <button className="help-button" onClick={this.toggleCloseKeyboardHelp} ref={(c) => { this.keyboardCloseHelpMark = c; }}><i className="far fa-question-circle" /></button>
+              {this.state.showCloseKeyboardHelp && (
+                <HelpModal
+                  helpBox={(c) => { this.helpBox = c; }}
+                  questionMark={this.keyboardCloseHelpMark}
+                  text={translate('helpModals.closeKeyboard')}
+                  togglePopup={this.toggleCloseKeyboardHelp}
+                />
+              )}
 
               {/* These buttons will be visible in Hebrew workflows as some manuscripts have both Arabic and Hebrew */}
               {this.props.manuscriptLanguage === LANGUAGES.HEBREW && (
@@ -450,6 +474,15 @@ class SelectedAnnotation extends React.Component {
                       </div>
                     )}
                     <FlippedBtn rtl={this.props.rtl} onClick={this.nextScript}>&#9658;</FlippedBtn>
+                    <button className="help-button" onClick={this.toggleScriptOptionsHelp} ref={(c) => { this.scriptOptionsHelpMark = c; }}><i className="far fa-question-circle" /></button>
+                    {this.state.showScriptOptionsHelp && (
+                      <HelpModal
+                        helpBox={(c) => { this.helpBox = c; }}
+                        questionMark={this.scriptOptionsHelpMark}
+                        text={translate('helpModals.scriptOptions')}
+                        togglePopup={this.toggleScriptOptionsHelp}
+                      />
+                    )}
                   </div>
                 </div>
                 <div className="round-toggle">

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -50,15 +50,11 @@ class SelectedAnnotation extends React.Component {
     this.toggleMarks = this.toggleMarks.bind(this);
     this.toggleScriptOptions = this.toggleScriptOptions.bind(this);
     this.toggleWhatsThis = this.toggleWhatsThis.bind(this);
-    this.toggleCloseKeyboardHelp = this.toggleCloseKeyboardHelp.bind(this);
-    this.toggleScriptOptionsHelp = this.toggleScriptOptionsHelp.bind(this);
 
     this.state = {
       disableSubmit: true,
-      showCloseKeyboardHelp: false,
-      showModifierHelp: false,
-      showScriptOptions: false,
-      showScriptOptionsHelp: false
+      helpPopup: null,
+      showScriptOptions: false
     };
   }
 
@@ -185,13 +181,11 @@ class SelectedAnnotation extends React.Component {
     if ((this.dropdown && this.dropdown.contains(e.target)) || (this.scriptToggle && this.scriptToggle.contains(e.target))) {
       return;
     }
-    if ((this.helpBox && this.helpBox.contains(e.target)) || (this.modifierHelpMark && this.modifierHelpMark.contains(e.target))) {
+    if ((this.helpBox && this.helpBox.contains(e.target)) || (this[this.state.helpPopup] && this[this.state.helpPopup].contains(e.target))) {
       return;
     }
-    if (this.state.showModifierHelp || this.state.showScriptOptions || this.state.showCloseKeyboardHelp || this.state.showScriptOptionsHelp) {
-      this.setState({ showModifierHelp: false });
-      this.setState({ showCloseKeyboardHelp: false });
-      this.setState({ showScriptOptionsHelp: false });
+    if (this.state.helpPopup || this.state.showScriptOptions) {
+      this.setState({ helpPopup: null, showScriptOptions: false });
     }
   }
 
@@ -306,16 +300,12 @@ class SelectedAnnotation extends React.Component {
     this.props.dispatch(setKeyboard(i));
   }
 
-  toggleWhatsThis() {
-    this.setState({ showModifierHelp: !this.state.showModifierHelp });
-  }
-
-  toggleCloseKeyboardHelp() {
-    this.setState({ showCloseKeyboardHelp: !this.state.showCloseKeyboardHelp });
-  }
-
-  toggleScriptOptionsHelp() {
-    this.setState({ showScriptOptionsHelp: !this.state.showScriptOptionsHelp });
+  toggleWhatsThis(component) {
+    if (this.state.helpPopup) {
+      this.setState({ helpPopup: null });
+    } else {
+      this.setState({ helpPopup: component });
+    }
   }
 
   scriptOption(script, i) {
@@ -350,6 +340,15 @@ class SelectedAnnotation extends React.Component {
     }
     return (
       <div className={ENABLE_DRAG} ref={(c) => { this.annotationBox = c; }}>
+        {this.state.helpPopup && (
+          <HelpModal
+            helpBox={(c) => { this.helpBox = c; }}
+            questionMark={this[this.state.helpPopup]}
+            text={translate(`helpModals.${this.state.helpPopup}`)}
+            togglePopup={this.toggleWhatsThis}
+          />
+        )}
+
         <div className="selected-annotation__header">
           <div>
             <h2 className="primary-label">{translate('transcribeBox.title')}</h2>
@@ -379,15 +378,8 @@ class SelectedAnnotation extends React.Component {
           placeholder={translate('transcribeBox.textArea')}
         />
         <div className="selected-annotation__text-modifiers">
-          <button onClick={this.toggleWhatsThis} ref={(c) => { this.modifierHelpMark = c; }}><i className="far fa-question-circle" /></button>
-          {this.state.showModifierHelp && (
-            <HelpModal
-              helpBox={(c) => { this.helpBox = c; }}
-              questionMark={this.modifierHelpMark}
-              text={translate('helpModals.textModifiers')}
-              togglePopup={this.toggleWhatsThis}
-            />
-          )}
+
+          <button ref={(c) => { this.modifierHelp = c; }} onClick={this.toggleWhatsThis.bind(this, 'modifierHelp')}><i className="far fa-question-circle" /></button>
           <button onClick={this.addTextModifier.bind(this, 'insertion')}>{this.props.translate('textModifiers.insertion')}</button>
           <button onClick={this.addTextModifier.bind(this, 'deletion')}>{this.props.translate('textModifiers.deletion')}</button>
           <button onClick={this.addTextModifier.bind(this, 'damaged')}>{this.props.translate('textModifiers.damaged')}</button>
@@ -414,15 +406,7 @@ class SelectedAnnotation extends React.Component {
             <div>
               <button className="small-btn" onClick={this.toggleKeyboardView}>{keyboardToggleText}</button>
 
-              <button className="help-button" onClick={this.toggleCloseKeyboardHelp} ref={(c) => { this.keyboardCloseHelpMark = c; }}><i className="far fa-question-circle" /></button>
-              {this.state.showCloseKeyboardHelp && (
-                <HelpModal
-                  helpBox={(c) => { this.helpBox = c; }}
-                  questionMark={this.keyboardCloseHelpMark}
-                  text={translate('helpModals.closeKeyboard')}
-                  togglePopup={this.toggleCloseKeyboardHelp}
-                />
-              )}
+              <button className="help-button" onClick={this.toggleWhatsThis.bind(this, 'keyboardHelp')} ref={(c) => { this.keyboardHelp = c; }}><i className="far fa-question-circle" /></button>
 
               {/* These buttons will be visible in Hebrew workflows as some manuscripts have both Arabic and Hebrew */}
               {this.props.manuscriptLanguage === LANGUAGES.HEBREW && (
@@ -474,15 +458,8 @@ class SelectedAnnotation extends React.Component {
                       </div>
                     )}
                     <FlippedBtn rtl={this.props.rtl} onClick={this.nextScript}>&#9658;</FlippedBtn>
-                    <button className="help-button" onClick={this.toggleScriptOptionsHelp} ref={(c) => { this.scriptOptionsHelpMark = c; }}><i className="far fa-question-circle" /></button>
-                    {this.state.showScriptOptionsHelp && (
-                      <HelpModal
-                        helpBox={(c) => { this.helpBox = c; }}
-                        questionMark={this.scriptOptionsHelpMark}
-                        text={translate('helpModals.scriptOptions')}
-                        togglePopup={this.toggleScriptOptionsHelp}
-                      />
-                    )}
+                    <button className="help-button" onClick={this.toggleWhatsThis.bind(this, 'scriptHelp')} ref={(c) => { this.scriptHelp = c; }}><i className="far fa-question-circle" /></button>
+
                   </div>
                 </div>
                 <div className="round-toggle">

--- a/src/components/WorkflowSelection.jsx
+++ b/src/components/WorkflowSelection.jsx
@@ -207,7 +207,7 @@ const mapStateToProps = state => {
     //We need to know if the user has any work that can be retrieved (either
     //from the Redux store of local storage) so we can prompt them to continue.
     activeAnnotationExists: (!!state.workflow.data && !!state.subject.currentSubject) || userHasWorkInProgress,
-    adminMode: true,
+    adminMode: state.login.adminMode,
     currentLanguage: getActiveLanguage(state.locale).code,
     translate: getTranslate(state.locale),
     user: state.login.user,  //Needed, otherwise component won't update when it detects a user login.

--- a/src/components/WorkflowSelection.jsx
+++ b/src/components/WorkflowSelection.jsx
@@ -199,7 +199,7 @@ WorkflowSelection.defaultProps = {
 const mapStateToProps = state => {
   const user = state.login.user;
   const userHasWorkInProgress = user && WorkInProgress.check(user);
-  
+
   return {
     //Does the user currently have a page being actively annotated, (e.g. user
     //navigated away from the Classifier page and wants to return), or have
@@ -207,7 +207,7 @@ const mapStateToProps = state => {
     //We need to know if the user has any work that can be retrieved (either
     //from the Redux store of local storage) so we can prompt them to continue.
     activeAnnotationExists: (!!state.workflow.data && !!state.subject.currentSubject) || userHasWorkInProgress,
-    adminMode: state.login.adminMode,
+    adminMode: true,
     currentLanguage: getActiveLanguage(state.locale).code,
     translate: getTranslate(state.locale),
     user: state.login.user,  //Needed, otherwise component won't update when it detects a user login.

--- a/src/locales/ar.js
+++ b/src/locales/ar.js
@@ -382,12 +382,12 @@ export default {
     deny: 'No, continue transcribing'
   },
   helpModals: {
-    closeKeyboard: 'Click here to hide/show the keyboard.',
-    scriptOptions: `
+    keyboardHelp: 'Click here to hide/show the keyboard.',
+    scriptHelp: `
       Scroll to choose a different script type for the keyboard. Visit the Script
       References section in the Crib Sheet for more information.
     `,
-    textModifiers: `
+    modifierHelp: `
       Use these text modifiers to indicate special occurrences. Highlight the
       text and click the applicable modifier. Find examples of each in the
       Field Guide.

--- a/src/locales/ar.js
+++ b/src/locales/ar.js
@@ -380,5 +380,17 @@ export default {
     question: 'Are you sure you want to close without saving?',
     confirm: 'Yes, close without saving',
     deny: 'No, continue transcribing'
+  },
+  helpModals: {
+    closeKeyboard: 'Click here to hide/show the keyboard.',
+    scriptOptions: `
+      Scroll to choose a different script type for the keyboard. Visit the Script
+      References section in the Crib Sheet for more information.
+    `,
+    textModifiers: `
+      Use these text modifiers to indicate special occurrences. Highlight the
+      text and click the applicable modifier. Find examples of each in the
+      Field Guide.
+    `
   }
 };

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -353,5 +353,17 @@ export default {
     question: 'Are you sure you want to close without saving?',
     confirm: 'Yes, close without saving',
     deny: 'No, continue transcribing'
+  },
+  helpModals: {
+    closeKeyboard: 'Click here to hide/show the keyboard.',
+    scriptOptions: `
+      Scroll to choose a different script type for the keyboard. Visit the Script
+      References section in the Crib Sheet for more information.
+    `,
+    textModifiers: `
+      Use these text modifiers to indicate special occurrences. Highlight the
+      text and click the applicable modifier. Find examples of each in the
+      Field Guide.
+    `
   }
 };

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -355,12 +355,12 @@ export default {
     deny: 'No, continue transcribing'
   },
   helpModals: {
-    closeKeyboard: 'Click here to hide/show the keyboard.',
-    scriptOptions: `
+    keyboardHelp: 'Click here to hide/show the keyboard.',
+    scriptHelp: `
       Scroll to choose a different script type for the keyboard. Visit the Script
       References section in the Crib Sheet for more information.
     `,
-    textModifiers: `
+    modifierHelp: `
       Use these text modifiers to indicate special occurrences. Highlight the
       text and click the applicable modifier. Find examples of each in the
       Field Guide.

--- a/src/locales/he.js
+++ b/src/locales/he.js
@@ -333,5 +333,17 @@ export default {
     question: '?בטוחים שאתם רוצים לסגור בלי לשמור',
     confirm: 'כן, סגור בלי לשמור',
     deny: 'לא, המשך לתעתק'
+  },
+  helpModals: {
+    closeKeyboard: 'Click here to hide/show the keyboard.',
+    scriptOptions: `
+      Scroll to choose a different script type for the keyboard. Visit the Script
+      References section in the Crib Sheet for more information.
+    `,
+    textModifiers: `
+      Use these text modifiers to indicate special occurrences. Highlight the
+      text and click the applicable modifier. Find examples of each in the
+      Field Guide.
+    `
   }
 };

--- a/src/locales/he.js
+++ b/src/locales/he.js
@@ -335,12 +335,12 @@ export default {
     deny: 'לא, המשך לתעתק'
   },
   helpModals: {
-    closeKeyboard: 'Click here to hide/show the keyboard.',
-    scriptOptions: `
+    keyboardHelp: 'Click here to hide/show the keyboard.',
+    scriptHelp: `
       Scroll to choose a different script type for the keyboard. Visit the Script
       References section in the Crib Sheet for more information.
     `,
-    textModifiers: `
+    modifierHelp: `
       Use these text modifiers to indicate special occurrences. Highlight the
       text and click the applicable modifier. Find examples of each in the
       Field Guide.

--- a/src/styles/components/selected-annotation.styl
+++ b/src/styles/components/selected-annotation.styl
@@ -80,7 +80,6 @@
     display: flex
     justify-content: flex-end
     margin: 0.75rem 0
-    position: relative
 
     button
       @extend .text-link

--- a/src/styles/components/text-modifier-help.styl
+++ b/src/styles/components/text-modifier-help.styl
@@ -4,7 +4,6 @@
   border-top: 8px solid $sand
   height: 10rem
   position: absolute
-  top: 3rem
   z-index: 1
 
   &:before
@@ -24,6 +23,8 @@
     margin: 0.75rem 1.25rem
 
   button
+    background-color: transparent
+    border: none
     text-decoration: none
 
   > div:first-child

--- a/src/styles/global/buttons.styl
+++ b/src/styles/global/buttons.styl
@@ -58,3 +58,7 @@
 
   &:hover
     background: $sand !important
+
+.help-button
+  background: none
+  border: none


### PR DESCRIPTION
Closes #97 

This PR adds a couple help modals to the `SelectedAnnotation` component. Overall, work was done to abstract the `TextModifierHelp` component so it could be used as a general help box. The refactor work here went a little too smoothly, so I'm curious if I missed something. All appears to be working. 