### PR TITLE
Add Timeout safety

### DIFF
--- a/src/components/ScriptReferences.jsx
+++ b/src/components/ScriptReferences.jsx
@@ -28,11 +28,11 @@ class ScriptReferences extends React.Component {
   }
   
   componentDidMount() { 
-    this.isMounted = true;
+    this._isMounted = true;
   }
 
   componentWillUnmount() {
-     this.isMounted = false;
+     this._isMounted = false;
   }
 
   sendToKeyboard() {
@@ -43,7 +43,7 @@ class ScriptReferences extends React.Component {
     this.props.dispatch(toggleKeyboard(true));
     this.setState({ keyboardSent: true });
     setTimeout(() => {
-      if (this.isMounted) {
+      if (this._isMounted) {
         this.setState({ keyboardSent: false });
       }
     }, 4000);

--- a/src/components/ScriptReferences.jsx
+++ b/src/components/ScriptReferences.jsx
@@ -26,14 +26,6 @@ class ScriptReferences extends React.Component {
       keyboardSent: false
     };
   }
-  
-  componentDidMount() { 
-    this._isMounted = true;
-  }
-
-  componentWillUnmount() {
-     this._isMounted = false;
-  }
 
   sendToKeyboard() {
     const script = this.props.activeScript;
@@ -43,9 +35,7 @@ class ScriptReferences extends React.Component {
     this.props.dispatch(toggleKeyboard(true));
     this.setState({ keyboardSent: true });
     setTimeout(() => {
-      if (this._isMounted) {
-        this.setState({ keyboardSent: false });
-      }
+      this.setState({ keyboardSent: false });
     }, 4000);
   }
 

--- a/src/components/ScriptReferences.jsx
+++ b/src/components/ScriptReferences.jsx
@@ -26,6 +26,14 @@ class ScriptReferences extends React.Component {
       keyboardSent: false
     };
   }
+  
+  componentDidMount() { 
+    this.isMounted = true;
+  }
+
+  componentWillUnmount() {
+     this.isMounted = false;
+  }
 
   sendToKeyboard() {
     const script = this.props.activeScript;
@@ -35,7 +43,9 @@ class ScriptReferences extends React.Component {
     this.props.dispatch(toggleKeyboard(true));
     this.setState({ keyboardSent: true });
     setTimeout(() => {
-      this.setState({ keyboardSent: false });
+      if (this.isMounted) {
+        this.setState({ keyboardSent: false });
+      }
     }, 4000);
   }
 

--- a/src/components/ScriptReferences.jsx
+++ b/src/components/ScriptReferences.jsx
@@ -25,6 +25,12 @@ class ScriptReferences extends React.Component {
     this.state = {
       keyboardSent: false
     };
+    
+    this.timer = undefined;
+  }
+  
+  componentWillUnmount() {
+    clearInterval(this.timer);
   }
 
   sendToKeyboard() {
@@ -34,7 +40,9 @@ class ScriptReferences extends React.Component {
     this.props.dispatch(toggleModern(true));
     this.props.dispatch(toggleKeyboard(true));
     this.setState({ keyboardSent: true });
-    setTimeout(() => {
+    
+    clearInterval(this.timer);
+    this.timer = setTimeout(() => {
       this.setState({ keyboardSent: false });
     }, 4000);
   }

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -49,11 +49,11 @@ class Toolbar extends React.Component {
   }
   
   componentDidMount() { 
-    this.isMounted = true;
+    this._isMounted = true;
   }
 
   componentWillUnmount() {
-     this.isMounted = false;
+     this._isMounted = false;
   }
 
   useZoomIn() {
@@ -85,7 +85,7 @@ class Toolbar extends React.Component {
     }
     if (!this.props.shownMarkReminder) {
       setTimeout(() => {
-        if (this.isMounted) {
+        if (this._isMounted) {
           this.toggleHelp();
         }
       }, 5000);

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -47,6 +47,14 @@ class Toolbar extends React.Component {
       showPanel: true
     };
   }
+  
+  componentDidMount() { 
+    this.isMounted = true;
+  }
+
+  componentWillUnmount() {
+     this.isMounted = false;
+  }
 
   useZoomIn() {
     this.props.dispatch(setScaling(this.props.scaling + ZOOM_STEP));
@@ -76,7 +84,11 @@ class Toolbar extends React.Component {
       this.props.dispatch(toggleReminder(null));
     }
     if (!this.props.shownMarkReminder) {
-      setTimeout(() => { this.toggleHelp(); }, 5000);
+      setTimeout(() => {
+        if (this.isMounted) {
+          this.toggleHelp();
+        }
+      }, 5000);
     }
     this.props.dispatch(setViewerState(SUBJECTVIEWER_STATE.ANNOTATING));
   }

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -46,6 +46,12 @@ class Toolbar extends React.Component {
     this.state = {
       showPanel: true
     };
+    
+    this.timer = undefined;
+  }
+  
+  componentWillUnmount() {
+    clearInterval(this.timer);
   }
 
   useZoomIn() {
@@ -76,7 +82,8 @@ class Toolbar extends React.Component {
       this.props.dispatch(toggleReminder(null));
     }
     if (!this.props.shownMarkReminder) {
-      setTimeout(() => { this.toggleHelp(); }, 5000);
+      clearInterval(this.timer);
+      this.timer = setTimeout(() => { this.toggleHelp(); }, 5000);
     }
     this.props.dispatch(setViewerState(SUBJECTVIEWER_STATE.ANNOTATING));
   }

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -47,14 +47,6 @@ class Toolbar extends React.Component {
       showPanel: true
     };
   }
-  
-  componentDidMount() { 
-    this._isMounted = true;
-  }
-
-  componentWillUnmount() {
-     this._isMounted = false;
-  }
 
   useZoomIn() {
     this.props.dispatch(setScaling(this.props.scaling + ZOOM_STEP));
@@ -84,11 +76,7 @@ class Toolbar extends React.Component {
       this.props.dispatch(toggleReminder(null));
     }
     if (!this.props.shownMarkReminder) {
-      setTimeout(() => {
-        if (this._isMounted) {
-          this.toggleHelp();
-        }
-      }, 5000);
+      setTimeout(() => { this.toggleHelp(); }, 5000);
     }
     this.props.dispatch(setViewerState(SUBJECTVIEWER_STATE.ANNOTATING));
   }

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -16,6 +16,12 @@ import HelperMessage from '../components/HelperMessage';
 import SubjectViewer from './SubjectViewer';
 
 class ClassifierContainer extends React.Component {
+  constructor() {
+    super();
+    
+    this.timer = undefined;
+  }
+  
   componentDidMount() {
     if (this.props.workflowStatus === WORKFLOW_STATUS.IDLE && !WorkInProgress.check(this.props.user)) {
       this.props.dispatch(togglePopup(<WorkflowPrompt />));
@@ -25,11 +31,14 @@ class ClassifierContainer extends React.Component {
   componentWillReceiveProps(next) {
     if (this.props.workflowStatus !== next.workflowStatus) {
       this.props.dispatch(togglePopup(null));
-      setTimeout(() => { this.toggleHelp(); }, 5000);
+      clearInterval(this.timer);
+      this.timer = setTimeout(() => { this.toggleHelp(); }, 5000);
     }
   }
 
   componentWillUnmount() {
+    clearInterval(this.timer);
+
     if (this.props.popup) {
       this.props.dispatch(togglePopup(null));
     }

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -17,6 +17,8 @@ import SubjectViewer from './SubjectViewer';
 
 class ClassifierContainer extends React.Component {
   componentDidMount() {
+    this.isMounted = true;
+    
     if (this.props.workflowStatus === WORKFLOW_STATUS.IDLE && !WorkInProgress.check(this.props.user)) {
       this.props.dispatch(togglePopup(<WorkflowPrompt />));
     }
@@ -25,11 +27,17 @@ class ClassifierContainer extends React.Component {
   componentWillReceiveProps(next) {
     if (this.props.workflowStatus !== next.workflowStatus) {
       this.props.dispatch(togglePopup(null));
-      setTimeout(() => { this.toggleHelp(); }, 5000);
+      setTimeout(() => {
+        if (this.isMounted) {
+          this.toggleHelp();
+        }
+      }, 5000);
     }
   }
 
   componentWillUnmount() {
+    this.isMounted = false;
+    
     if (this.props.popup) {
       this.props.dispatch(togglePopup(null));
     }

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -17,8 +17,6 @@ import SubjectViewer from './SubjectViewer';
 
 class ClassifierContainer extends React.Component {
   componentDidMount() {
-    this._isMounted = true;
-    
     if (this.props.workflowStatus === WORKFLOW_STATUS.IDLE && !WorkInProgress.check(this.props.user)) {
       this.props.dispatch(togglePopup(<WorkflowPrompt />));
     }
@@ -27,17 +25,11 @@ class ClassifierContainer extends React.Component {
   componentWillReceiveProps(next) {
     if (this.props.workflowStatus !== next.workflowStatus) {
       this.props.dispatch(togglePopup(null));
-      setTimeout(() => {
-        if (this._isMounted) {
-          this.toggleHelp();
-        }
-      }, 5000);
+      setTimeout(() => { this.toggleHelp(); }, 5000);
     }
   }
 
   componentWillUnmount() {
-    this._isMounted = false;
-    
     if (this.props.popup) {
       this.props.dispatch(togglePopup(null));
     }

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -17,7 +17,7 @@ import SubjectViewer from './SubjectViewer';
 
 class ClassifierContainer extends React.Component {
   componentDidMount() {
-    this.isMounted = true;
+    this._isMounted = true;
     
     if (this.props.workflowStatus === WORKFLOW_STATUS.IDLE && !WorkInProgress.check(this.props.user)) {
       this.props.dispatch(togglePopup(<WorkflowPrompt />));
@@ -28,7 +28,7 @@ class ClassifierContainer extends React.Component {
     if (this.props.workflowStatus !== next.workflowStatus) {
       this.props.dispatch(togglePopup(null));
       setTimeout(() => {
-        if (this.isMounted) {
+        if (this._isMounted) {
           this.toggleHelp();
         }
       }, 5000);
@@ -36,7 +36,7 @@ class ClassifierContainer extends React.Component {
   }
 
   componentWillUnmount() {
-    this.isMounted = false;
+    this._isMounted = false;
     
     if (this.props.popup) {
       this.props.dispatch(togglePopup(null));


### PR DESCRIPTION
## PR Overview
This PR fixes #39 , which states that there's a potential for bad things to happen if a Timeout function attempts to use parts of React component that's not mounted (notably, this.setState()).

Technically simple, but there were shenanigans in the implementation.

### Dev Notes
1. Uh... I had to name the variables `this._isMounted` instead of `this.isMounted` because the latter actually causes the app to crash. Not kidding, this is what Chrome complained about: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Getter_only

Does anyone have insights into this? Does the `_` underscore prefix somehow make variables private vars, via Babel or React? Something something? This is one of those implicit things that I was hitherto unaware of.

2. I only checked `if (this._isMounted)` and not `if (this && this._isMounted)` because the `()=>{}` statement should ensure a `this` reference is always bounded (bound? binded?).

3. Technically, only ScriptReferences.jsx had any real potential to cause trouble since it's the only component whose Timeout function uses `this.setState()`, whereas the other components only trigger Redux store updates. Still, functionally, it's better this way to avoid weird "something happened on a page that I wasn't looking at" issues.

### Status
@wgranger behold the weirdness.