### PR TITLE
Use Pandora Translations for Finished Prompt

### DIFF
--- a/src/components/FinishedPrompt.jsx
+++ b/src/components/FinishedPrompt.jsx
@@ -89,11 +89,8 @@ class FinishedPrompt extends React.Component {
               {task.answers.map((answer, answerIndex) => {
                 const checked = this.props.subjectCompletionAnswers &&
                   this.props.subjectCompletionAnswers[task.taskId] === answerIndex;
-                let label = answer.label;
-                const currentLabel = translations[`tasks.${currentTask}.answers.${answerIndex}.label`];
-                if (translations && currentLabel) {
-                  label = currentLabel;
-                }
+                const labelTranslation = translations && translations[`tasks.${currentTask}.answers.${answerIndex}.label`];
+                const label = labelTranslation || answer.label;
 
                 return (
                   <div

--- a/src/ducks/translations.js
+++ b/src/ducks/translations.js
@@ -17,7 +17,8 @@ const initialState = {
   status: TRANSLATION_STATUS.IDLE,
   strings: {
     field_guide: {},
-    tutorial: {}
+    tutorial: {},
+    workflow: {}
   }
 };
 

--- a/src/ducks/workflow.js
+++ b/src/ducks/workflow.js
@@ -6,6 +6,7 @@ import { resetSubject } from './subject';
 import { resetAnnotations } from './annotations';
 import { fetchTutorial } from './tutorial';
 import { toggleLanguage } from './keyboard';
+import { loadTranslations } from './translations';
 
 // Action Types
 const FETCH_WORKFLOW = 'FETCH_WORKFLOW';
@@ -75,7 +76,8 @@ const workflowReducer = (state = initialState, action) => {
 /*  Resets all the dependencies that rely on the Workflow.
  */
 const prepareForNewWorkflow = () => {
-  return (dispatch) => {
+  return (dispatch, getState) => {
+    dispatch(loadTranslations('workflow', getState().workflow.id));
     dispatch(resetSubject());
     dispatch(resetAnnotations());
     dispatch(fetchTutorial());


### PR DESCRIPTION
We currently use local translations for the `FinishedPrompt` component. However, in order to keep content and translations for this modal flexible for project owners, the `FinishedPrompt` now renders text from Pandora. 

If there is no translation from Pandora, the modal will fallback on local translations (header and instructions) or content in the English translation (answer labels).

This is how text will render from the project builder to the modal:
![screen shot 2019-02-05 at 2 11 32 pm](https://user-images.githubusercontent.com/14099077/52301542-40098900-2950-11e9-8001-4902fffbe156.png)
