### PR TITLE
Use Different "Copy" Icon for SVG Overlay

### DIFF
--- a/src/components/AggregationsPane.jsx
+++ b/src/components/AggregationsPane.jsx
@@ -124,12 +124,11 @@ class AggregationsPane extends React.Component {
               </text>
               <text
                 id={`${uniqueKey}_icon`}
-                fontFamily="FontAwesome"
                 fontSize="2.5em"
                 x={x + BUFFER}
                 y={y - BUFFER}
               >
-                &#xf0c5;
+                &#x2398;
               </text>
             </g>
           );

--- a/src/components/AggregationsPane.jsx
+++ b/src/components/AggregationsPane.jsx
@@ -124,11 +124,12 @@ class AggregationsPane extends React.Component {
               </text>
               <text
                 id={`${uniqueKey}_icon`}
+                fontFamily="Font Awesome\ 5 Free"
                 fontSize="2.5em"
                 x={x + BUFFER}
                 y={y - BUFFER}
               >
-                &#x2398;
+                &#xf0c5;
               </text>
             </g>
           );


### PR DESCRIPTION
With the update to FontAwesome 5, our previous solution to display an FA icon in an SVG `<text>` element no longer works. I've removed the Font Awesome className here in lieu of a more straightforward Unicode character.

You should see this icon, and the SVG overlay, if you enter the "Challenging Hebrew" workflow in staging.