### PR TITLE
Arabic translations update (Aug 2018), Except Properly This Time

### DIFF
--- a/src/components/AnnotationKeyboard.jsx
+++ b/src/components/AnnotationKeyboard.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
+import { getTranslate, getActiveLanguage } from 'react-localize-redux';
 import { LANGUAGES } from '../ducks/keyboard';
 import MODERN_HEBREW from '../lib/HebrewKeyboard';
 import MODERN_ARABIC from '../lib/ArabicKeyboard';
@@ -80,7 +81,12 @@ class AnnotationKeyboard extends React.Component {
       <div key={`KEYBOARD_ROW_${i}`} className="annotation-keyboard__row">
         {row.map(letter => this.renderKey(letter))}
         {i === 1 && (
-          <button className="annotation-keyboard__button enter-button" onClick={this.props.onEnter}>Enter</button>
+          <button
+            className="annotation-keyboard__button enter-button"
+            onClick={this.props.onEnter}
+          >
+            {this.props.translate('keyboard.enter')}
+          </button>
         )}
       </div>
     );
@@ -97,7 +103,7 @@ class AnnotationKeyboard extends React.Component {
             })}
             onClick={this.props.onLetterClick}
           >
-            Space
+            {this.props.translate('keyboard.space')}
           </button>
         </div>
       </div>
@@ -115,7 +121,8 @@ AnnotationKeyboard.propTypes = {
   keyboardLanguage: PropTypes.string,
   onLetterClick: PropTypes.func,
   onEnter: PropTypes.func,
-  showModern: PropTypes.bool
+  showModern: PropTypes.bool,
+  translate: PropTypes.func
 };
 
 AnnotationKeyboard.defaultProps = {
@@ -124,14 +131,17 @@ AnnotationKeyboard.defaultProps = {
   keyboardLanguage: LANGUAGES.HEBREW,
   onLetterClick: () => {},
   onEnter: () => {},
-  showModern: true
+  showModern: true,
+  translate: () => {}
 };
 
 const mapStateToProps = state => ({
   activeKey: state.keyboard.activeKey,
   activeScript: state.keyboard.activeScript,
+  currentLanguage: getActiveLanguage(state.locale).code,
   keyboardLanguage: state.keyboard.activeLanguage,
-  showModern: state.keyboard.modern
+  showModern: state.keyboard.modern,
+  translate: getTranslate(state.locale)
 });
 
 export default connect(mapStateToProps)(AnnotationKeyboard);

--- a/src/components/ScriptReferences.jsx
+++ b/src/components/ScriptReferences.jsx
@@ -135,7 +135,7 @@ class ScriptReferences extends React.Component {
           </button>
           {this.state.keyboardSent && (
             <span>
-              {this.scriptTranslate()} is now active in your transcription keyboard
+              {this.scriptTranslate()} {this.props.translate('scriptReferences.isActive')}
             </span>
           )}
         </div>

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -136,7 +136,7 @@ class Toolbar extends React.Component {
 
   toggleHelp() {
     if (!this.props.shownMarkReminder) {
-      const message = 'Click at the start and end of a line of text to add a transcription (remember to start on the right side!)';
+      const message = this.props.translate('helpers.click');
       this.props.dispatch(toggleReminder(
         <HelperMessage message={message} width={565} />
       ));

--- a/src/components/about/content-intro-ar.jsx
+++ b/src/components/about/content-intro-ar.jsx
@@ -21,7 +21,7 @@ function Content() {
       </p>
       <div className="diagram">
         <img src={imgPhase1Workflow} />
-        <span className="caption">المرحلة الأولى عمل</span>
+        <span className="caption">تصنيف سير العمل</span>
       </div>
       <p className="text">الآن نحن في مرحلة النسخ أو المرحلة الثانية والهدف منها هو:</p>
       <ol className="text">

--- a/src/components/about/content-intro-he.jsx
+++ b/src/components/about/content-intro-he.jsx
@@ -28,7 +28,7 @@ function Content() {
       </p>
       <div className="diagram">
         <img src={imgPhase1Workflow} />
-        <span className="caption">Phase One Workflow</span>
+        <span className="caption">מהלך עבודה של הסיווג</span>
       </div>
       <p className="text">
         עתה אנו מצויים בשלב הסיווג, יחד עם העתקת הקטעים ואיתור מילות מפתח. מטרות יצירת התעתיקים וחיפוש

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { getTranslate, getActiveLanguage } from 'react-localize-redux';
 
 import { togglePopup } from '../ducks/dialog';
 import { shownStartReminder, toggleReminder } from '../ducks/reminder';
@@ -46,7 +47,7 @@ class ClassifierContainer extends React.Component {
 
   toggleHelp() {
     if (!this.props.shownBeginReminder) {
-      const message = 'Get Started by clicking "Add Transcription"';
+      const message = this.props.translate('helpers.getStarted');
       this.props.dispatch(shownStartReminder());
       this.props.dispatch(toggleReminder(
         <HelperMessage message={message} width={275} />
@@ -96,6 +97,7 @@ ClassifierContainer.propTypes = {
     width: PropTypes.number
   }),
   shownBeginReminder: PropTypes.bool,
+  translate: PropTypes.func,
   user: PropTypes.shape({
     id: PropTypes.string
   }),
@@ -110,6 +112,7 @@ ClassifierContainer.defaultProps = {
   popup: null,
   size: { height: 200, width: 200 },
   shownBeginReminder: false,
+  translate: () => {},
   user: null
 };
 
@@ -118,11 +121,13 @@ const mapStateToProps = state => ({
   annotationPaneSize: state.dialog.annotationPaneSize,
   annotationPaneOffset: state.dialog.annotationPaneOffset,
   component: state.dialog.component,
+  currentLanguage: getActiveLanguage(state.locale).code,
   dialog: state.dialog.data,
   popup: state.dialog.popup,
   size: state.dialog.size,
   shownBeginReminder: state.reminder.shownBeginReminder,
   subjectStatus: state.subject.status,
+  translate: getTranslate(state.locale),
   user: state.login.user,
   workflowStatus: state.workflow.status
 });

--- a/src/locales/ar.js
+++ b/src/locales/ar.js
@@ -8,12 +8,10 @@ export default {
     rotate: 'تدوير',
     invertColors: 'عكس الألوان',
     showHints: `
-      إظهار مساعدة للكلمة
-      الرئيسية
+      إظهار مساعدة للكلمة الرئيسية
     `,
     hideHints: `
-      إخفاء مساعدة للكلمة
-      الرئيسية
+      إخفاء مساعدة للكلمة الرئيسية
     `,
     showingMarks: 'إظهار العلامات السابقة',
     hidingMarks: 'توسيع المعلومات',
@@ -32,14 +30,8 @@ export default {
       صفحة فهرس
       المكتبة
     `,
-    collapseName: `
-      اخفاء الاسم
-      والمصدر
-    `,
-    expandName: `
-      إظهار الاسم
-      والمصدر
-    `,
+    collapseName: `اخفاء الاسم والمصدر`,
+    expandName: `إظهار الاسم والمصدر`,
     showCrib: `
       إظهار الورقة
       المرجعية
@@ -113,6 +105,10 @@ export default {
     showModern: 'إظهار الحروف الحديثة',
     showMarks: 'عرض العلامات السابقة'
   },
+  keyboard: {
+    enter: 'مفتاح الإدخال',
+    space: 'مفتاح المسافة'
+  },
   collection: {
     title: 'إضافة إلى مجموعة',
     addTo: 'إضافة إلى مجموعة موجودة',
@@ -158,7 +154,9 @@ export default {
     filterBy: 'فرز الخطوط حسب',
     cursive: 'بحروف متصلة',
     minuscule: 'ضئيلة',
-    square: 'مربعة'
+    square: 'مربعة',
+    isActive: 'هو الآن مفعل في لوحة مفاتيح النسخ الخاصة بك',
+    sent: 'إرسال'
   },
   cribSheet: {
     title: 'ورقة مرجعية',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -9,8 +9,8 @@ export default {
     invertColors: 'Invert Colors',
     showHints: 'Show Keyword Hints',
     hideHints: 'Hide Keyword Hints',
-    showingMarks: 'Showing Previous Marks',
-    hidingMarks: 'Hiding Previous Marks',
+    showingMarks: 'Show Previous Marks',
+    hidingMarks: 'Hide Previous Marks',
     resetImage: 'Reset Image',
     addFavorites: 'Add to Favorites',
     addCollection: 'Add to Collection'
@@ -72,6 +72,10 @@ export default {
     showModern: 'Show Modern Characters',
     showMarks: 'Show Previous Marks'
   },
+  keyboard: {
+    enter: 'Enter',
+    space: 'Space'
+  },
   collection: {
     title: 'Add to Collection',
     addTo: 'Add to an existing collection',
@@ -118,7 +122,9 @@ export default {
     filterBy: 'Filter Scripts By',
     cursive: 'Cursive',
     minuscule: 'Minuscule',
-    square: 'Square'
+    square: 'Square',
+    isActive: 'is now active in your transcription keyboard',
+    sent: 'Sent'
   },
   cribSheet: {
     title: 'Crib Sheet',
@@ -140,7 +146,7 @@ export default {
   },
   helpers: {
     getStarted: 'Get started by clicking "Add Transcription"',
-    click: 'Click at the start and end of a line of text to add a transcription',
+    click: 'Click at the start and end of a line of text to add a transcription (remember to start on the right side!)',
     draw: 'Draw a box around the part of the iamge you\'d like to save',
     copied: 'Text copied to your clipboard! Paste into your text transcription box.'
   },

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -435,7 +435,7 @@ export default {
       people-powered research. This research is made possible by
       volunteers-;hundreds of thousands of people around the world who
       come together to assist professional researchers. Our goal is to enable
-      reearch that would not be possible, or practical, otherwise. Zooniverse
+      research that would not be possible, or practical, otherwise. Zooniverse
       research results in new discoveries, datasets useful to the wider research
       community, and many publications.
     `

--- a/src/locales/he.js
+++ b/src/locales/he.js
@@ -72,6 +72,10 @@ export default {
     showModern: 'הצג מקלדת רגילה',
     showMarks: 'הראה סימוני שורות שנעשו בעבר'
   },
+  keyboard: {
+    enter: 'מעבר שורה',
+    space: 'רווח'
+  },
   collection: {
     title: 'הוסף לאוסף',
     addTo: 'הוסף לאוסף קיים',
@@ -117,7 +121,9 @@ export default {
     filterBy: 'סנן סוגי כתב',
     cursive: 'רהוט',
     minuscule: 'בינוני',
-    square: 'מרובע'
+    square: 'מרובע',
+    isActive: 'פעיל עתה במקלדת התעתוק שלך',
+    sent: 'נשלח למקלדת'
   },
   cribSheet: {
     title: 'סוגי כתב',


### PR DESCRIPTION
## PR Overview

Right, so we had PR #129 which added Arabic translations _and more stuff,_ but it's been so out of date and we've had hot new translations coming in that that PR's pretty much out of sync.

Anyway, so that means _that_ PR is no longer safe to be merged, which is a problem because the aforementioned _more stuff_ includes things like translations for the words "Enter" and "Space" for the Annotation keyboard and small typo fixes for Zooniverse's reearch. So _this_ PR is a redo of _that_ PR #129, adding all the missing additions (note: I think most of the translation files are actually fine, it's just the miscellaneous _more stuff_ that's borked) but without the gooey merge conflicts.

### Status

@wgranger I'm going to need your help to review this once it's ready. Pinging @snblickhan FYI