### PR TITLE
Add Maintenance Banner

### DIFF
--- a/src/index.tpl.html
+++ b/src/index.tpl.html
@@ -19,8 +19,9 @@
   <body style="background-color: transparent; text-align: center; margin: 1em">
     <h1>Under maintenance</h1>
     <p style="margin-bottom: 0">Scribes of the Cairo Geniza is currently under maintenance.</p>
-    <p>We'll be up again in an hour.</p>
-    <p>We apologize for any inconvenience.</p>
+    <p>We'll be up again in an soon.</p>
+    <p>You can keep up-to-date with the status of the Zooniverse platform at all times via our page at <a href="https://status.zooniverse.org">status.zooniverse.org</a>, and via our <a href="https://twitter.com/the_zooniverse">Twitter account</a>.</p>
+    
     <script src="https://ft-polyfill-service.herokuapp.com/v2/polyfill.min.js?features=default,es6,Array.prototype.includes,Array.prototype.keys"></script>
   </body>
 </html>

--- a/src/index.tpl.html
+++ b/src/index.tpl.html
@@ -16,8 +16,11 @@
 
     <meta name="google-site-verification" content="k5HGFzHxciKSJySNjb7_IfMVlJ-m1g0QwB_yD2i8qVU" /><!--Identifier for Google Webmasters tools-->
   </head>
-  <body>
-    <div id="root"></div>
+  <body style="background-color: transparent; text-align: center; margin: 1em">
+    <h1>Under maintenance</h1>
+    <p style="margin-bottom: 0">Scribes of the Cairo Geniza is currently under maintenance.</p>
+    <p>We'll be up again in an hour.</p>
+    <p>We apologize for any inconvenience.</p>
     <script src="https://ft-polyfill-service.herokuapp.com/v2/polyfill.min.js?features=default,es6,Array.prototype.includes,Array.prototype.keys"></script>
   </body>
 </html>


### PR DESCRIPTION
Adds a maintenance banner to account for scheduled Zooniverse downtime based on a [PR](https://github.com/zooniverse/Panoptes-Front-End/pull/5770) by @shaunanoordin.

<img width="599" alt="Screen Shot 2020-07-21 at 9 28 03 AM" src="https://user-images.githubusercontent.com/14099077/88067521-b4c88700-cb34-11ea-9a7c-3488cca76637.png">
