### PR TITLE
Add 'Hebrew Language Review' external workflow

### DIFF
--- a/src/components/WorkflowSelection.jsx
+++ b/src/components/WorkflowSelection.jsx
@@ -78,6 +78,15 @@ const WorkflowSelection = ({ adminMode, className, dispatch, location, history, 
             >
               {translate('workflowSelection.phaseOne')} <i className="fa fa-external-link-alt" />
             </a>
+            <a
+              className="tertiary-label"
+              href={`${classifyPath}${c.hebrewLanguageReview}`}
+              rel="noopener noreferrer"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {translate('workflowSelection.hebrewLanguageReview')} <i className="fa fa-external-link-alt" />
+            </a>
           </div>
           <div>
             <span className="h1-font">{translate('general.hebrew')}</span>

--- a/src/components/WorkflowSelection.jsx
+++ b/src/components/WorkflowSelection.jsx
@@ -69,6 +69,7 @@ const WorkflowSelection = ({ adminMode, className, dispatch, location, history, 
       {showAllWorkflows && (
         <div>
           <div>
+            <span className="h1-font">{translate('workflowSelection.phaseOne')}</span>
             <a
               className="tertiary-label"
               href={`${classifyPath}${c.phaseOne}`}
@@ -76,7 +77,7 @@ const WorkflowSelection = ({ adminMode, className, dispatch, location, history, 
               target="_blank"
               rel="noopener noreferrer"
             >
-              {translate('workflowSelection.phaseOne')} <i className="fa fa-external-link-alt" />
+              {translate('workflowSelection.sortFragments')} <i className="fa fa-external-link-alt" />
             </a>
             <a
               className="tertiary-label"

--- a/src/config.js
+++ b/src/config.js
@@ -36,6 +36,7 @@ const baseConfig = {
     phaseOne: '3157',
     arabicKeyword: '3201',
     hebrewKeyword: '3156',
+    hebrewLanguageReview: '',  // Not available as of Feb 2021
     consensusLineReductions: {
       3203: 'ext-18',
       3202: 'ext-19',
@@ -56,6 +57,7 @@ const baseConfig = {
     phaseOne: '4712',
     arabicKeyword: '6600',
     hebrewKeyword: '6529',
+    hebrewLanguageReview: '13157',  // New category, added Feb 2021 - see https://github.com/zooniverse/scribes-of-the-cairo-geniza/issues/204
     consensusLineReductions: {
       6652: 'T0-text-transcription',
       6654: 'T0-text-transcription',

--- a/src/locales/ar.js
+++ b/src/locales/ar.js
@@ -82,9 +82,10 @@ export default {
     letsGo: 'بداية'
   },
   workflowSelection: {
-    phaseOne: 'المرحلة الأولى: فرز القطع',
+    phaseOne: 'المرحلة الأولى',
     phaseTwo: 'المرحلة الثانية: النسخ',
     keywordSearch: 'العثور على العبارة',
+    sortFragments: 'فرز القطع',
     hebrewLanguageReview: 'Hebrew Language Review',
     continue: 'مواصلة العمل في التقدم',
     choose: 'اختر سير عمل'

--- a/src/locales/ar.js
+++ b/src/locales/ar.js
@@ -85,6 +85,7 @@ export default {
     phaseOne: 'المرحلة الأولى: فرز القطع',
     phaseTwo: 'المرحلة الثانية: النسخ',
     keywordSearch: 'العثور على العبارة',
+    hebrewLanguageReview: 'Hebrew Language Review',
     continue: 'مواصلة العمل في التقدم',
     choose: 'اختر سير عمل'
   },

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -51,9 +51,10 @@ export default {
     letsGo: 'Let\'s Go'
   },
   workflowSelection: {
-    phaseOne: 'Phase One: Sort Fragments',
+    phaseOne: 'Phase One',
     phaseTwo: 'Phase Two: Transcription',
     keywordSearch: 'Phrase Finding',
+    sortFragments: 'Sort Fragments',  // Previously "phaseOne"
     hebrewLanguageReview: 'Hebrew Language Review',  // New category, added Feb 2021 - see https://github.com/zooniverse/scribes-of-the-cairo-geniza/issues/204
     continue: 'Continue work in progress',
     choose: 'Choose a workflow'

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -54,6 +54,7 @@ export default {
     phaseOne: 'Phase One: Sort Fragments',
     phaseTwo: 'Phase Two: Transcription',
     keywordSearch: 'Phrase Finding',
+    hebrewLanguageReview: 'Hebrew Language Review',  // New category, added Feb 2021 - see https://github.com/zooniverse/scribes-of-the-cairo-geniza/issues/204
     continue: 'Continue work in progress',
     choose: 'Choose a workflow'
   },

--- a/src/locales/he.js
+++ b/src/locales/he.js
@@ -51,9 +51,10 @@ export default {
     letsGo: 'להתחיל'
   },
   workflowSelection: {
-    phaseOne: 'שלב I: סיווג קטעי הגניזה',
+    phaseOne: 'שלב I',
     phaseTwo: 'שלב II: העתקת קטעי הגניזה',
     keywordSearch: 'איתור מילות מפתח',
+    sortFragments: 'סיווג קטעי הגניזה',
     hebrewLanguageReview: 'סיווג שפת הכתיבה',
     continue: 'המשך בתהליך העבודה',
     choose: 'בחרו משימה'

--- a/src/locales/he.js
+++ b/src/locales/he.js
@@ -54,6 +54,7 @@ export default {
     phaseOne: 'שלב I: סיווג קטעי הגניזה',
     phaseTwo: 'שלב II: העתקת קטעי הגניזה',
     keywordSearch: 'איתור מילות מפתח',
+    hebrewLanguageReview: 'סיווג שפת הכתיבה',
     continue: 'המשך בתהליך העבודה',
     choose: 'בחרו משימה'
   },


### PR DESCRIPTION
## PR Overview

Closes #204

This PR adds a new workflow to the "Choose A Workflow" menu, as requested on 204.

- The "Choose A Workflow" menu can be seen by navigating to `/classify`
- The link, titled "Hebrew Language Review", is to an external workflow on zooniverse.org.
  - It's workflow ID 13157 on production (https://www.zooniverse.org/projects/judaicadh/scribes-of-the-cairo-geniza/classify?workflow=13157)
  - There's NO equivalent workflow on staging.

<img width="709" alt="Screen Shot 2021-02-12 at 14 32 22" src="https://user-images.githubusercontent.com/13952701/107781117-6fbda980-6d3f-11eb-874c-28ef76988d58.png">

I'm genuinely not sure how the links are supposed to be categorised (is Hebrew Language Review part of Phase One? Phase Two? Its own thing? Does it needs its own "wild card" category?), or rather _how the new link should be organised visually._

@snblickhan , please tag Becky in if the screenshot above needs revision. ☝️ 

###  Status

Ready for review, but I ain't merging nor deploying until Sam gets a chance to look at this.