### PR TITLE
Add graphql dependency for graphql-request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "scribes-of-the-cairo-geniza",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "~2.2.6",
         "counterpart": "^0.18.6",
+        "graphql": "~15.7.2",
         "graphql-request": "~3.6.1",
         "history": "~4.6.3",
         "lodash": "~4.17.19",
@@ -9616,7 +9616,6 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
       "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==",
-      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -29008,8 +29007,7 @@
     "graphql": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
-      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==",
-      "peer": true
+      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A=="
     },
     "graphql-request": {
       "version": "3.6.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "classnames": "~2.2.6",
     "counterpart": "^0.18.6",
+    "graphql": "~15.7.2",
     "graphql-request": "~3.6.1",
     "history": "~4.6.3",
     "lodash": "~4.17.19",


### PR DESCRIPTION
In attempt to deploy, during build process, received the following error:
```
ERROR in ./node_modules/graphql-request/dist/index.js
Module not found: Error: Can't resolve 'graphql/language/printer'
```

This PR adds `graphql` as a dependency so `graphql-request` won't throw noted error.