### PR TITLE
Upgrade Node to 16, fix deployment

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -21,8 +21,8 @@ jobs:
     - name: Node install and build
       uses: actions/setup-node@v1
       with:
-        node-version: '14.x'
-    - run: npm install
+        node-version: '16.x'
+    - run: npm ci
     - run: npm run build
 
     - name: Upload to blob storage

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "BABEL_ENV=production check-engines && check-dependencies && webpack --config webpack.production.config.js -p"
   },
   "engines": {
-    "node": ">=14",
+    "node": ">=16",
     "npm": ">=7"
   },
   "author": "Zooniverse",


### PR DESCRIPTION
## PR Overview

Mirror of https://github.com/zooniverse/anti-slavery-manuscripts/pull/356

This PR fixes the GitHub Action deployment. Currently, the deployment is failing due to an older version of `npm` (tied with node 14) trying to install packages from a package-lock.json created by newer versions of `npm`

- Now we're using `node 16`, which should come with the newer versions of npm
- `npm install` has also been replaced with `npm ci`