### PR TITLE
Update GitHub Actions to use node v16.14.x

### DIFF
--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -10,6 +10,6 @@ jobs:
     uses: zooniverse/ci-cd/.github/workflows/npm_build.yaml@main
     with:
       commit_id: ${{ github.sha }}
-      node_version: '16.x'
+      node_version: '16.14.x'
       output: 'dist'
       script: 'build'

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -15,7 +15,7 @@ jobs:
     uses: zooniverse/ci-cd/.github/workflows/npm_build.yaml@main
     with:
       commit_id: ${{ github.sha }}
-      node_version: '16.x'
+      node_version: '16.14.x'
       output: 'dist'
       script: 'build'
   deploy:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -15,7 +15,7 @@ jobs:
     uses: zooniverse/ci-cd/.github/workflows/npm_build.yaml@main
     with:
       commit_id: ${{ github.sha }}
-      node_version: '16.x'
+      node_version: '16.14.x'
       output: 'dist'
       script: 'build'
   deploy:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -16,6 +16,6 @@ jobs:
     - name: Node.js build
       uses: actions/setup-node@v1
       with:
-        node-version: '16.x'
+        node-version: '16.14.x'
     - run: npm install
     - run: npm test


### PR DESCRIPTION
As noted in other repos using Node v16.15 or higher in builds (latest build issues in this repo are with Node v16.16) - builds with Node > 16.15 fail with unmatched peer dependency errors - new Node versions are more strict about nested dependencies.

This PR sets node to v16.14 to fix the builds.

Related to zooniverse/anti-slavery-manuscripts/pull/365 .