### PR TITLE
Add "Paused Banner" (Apr 2024)

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -11,6 +11,7 @@ import AuthContainer from '../containers/AuthContainer';
 import ClassifierContainer from '../containers/ClassifierContainer';
 import Home from './Home';
 import ProjectHeader from '../containers/ProjectHeader';
+import AppBanner from './AppBanner';
 
 class App extends React.Component {
   componentWillMount() {
@@ -29,6 +30,7 @@ class App extends React.Component {
         <header className="app-header">
           <ZooHeader authContainer={<AuthContainer />} />
         </header>
+        <AppBanner /> {/* Added 3 Apr 2024 */}
         <section className="content-section">
           <ProjectHeader location={this.props.location} />
           <Switch>

--- a/src/components/AppBanner.jsx
+++ b/src/components/AppBanner.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { getActiveLanguage } from 'react-localize-redux';
+import PropTypes from 'prop-types';
+
+const AppBanner = ({ currentLanguage }) => {
+  switch (currentLanguage) {
+    case 'he': return (
+      <div className="app-banner">
+        התמלול על פרויקט זה הושלם כעת. תודה על כל העזרה שלך! אנא עיין ב-<a href="https://www.zooniverse.org/about/publications">Zooniverse Publications Page</a> לתוצאות.
+      </div>
+    );
+    case 'ar': return (
+      <div className="app-banner">
+        اكتمل النسخ في هذا المشروع حاليًا. شكرا لكم على كل ما تبذلونه من مساعدة! يرجى الاطلاع على <a href="https://www.zooniverse.org/about/publications">Zooniverse Publications Page</a> للحصول على النتائج.
+      </div>
+    );
+    default: return (
+      <div className="app-banner">
+        Transcription on this project is currently complete. Thank you for all your help! Please see the <a href="https://www.zooniverse.org/about/publications">Zooniverse Publications Page</a> for results.
+      </div>
+    );
+  }
+};
+
+AppBanner.propTypes = {
+  currentLanguage: PropTypes.string.isRequired
+};
+
+AppBanner.defaultProps = {};
+
+const mapStateToProps = state => ({
+  currentLanguage: getActiveLanguage(state.locale).code
+});
+
+export default connect(mapStateToProps)(AppBanner);

--- a/src/index.tpl.html
+++ b/src/index.tpl.html
@@ -18,6 +18,5 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="https://ft-polyfill-service.herokuapp.com/v2/polyfill.min.js?features=default,es6,Array.prototype.includes,Array.prototype.keys"></script>
   </body>
 </html>

--- a/src/styles/components/app-banner.styl
+++ b/src/styles/components/app-banner.styl
@@ -1,0 +1,4 @@
+.app-banner
+  padding: 0.5rem 3.5rem
+  background: $light-teal
+  text-align: center


### PR DESCRIPTION
## PR Overview

Closes #719

This PR adds a simple banner to the Scribes of the Cairo Geniza website, to announce that transcriptions for the project is currently complete.

<img width="600" alt="image" src="https://github.com/zooniverse/scribes-of-the-cairo-geniza/assets/13952701/e92c977c-c38d-45fd-89b2-134a5aa0a9d6">


- A new `AppBanner` component has been added, which allows for language-switching (languge-specific messages)
- Misc: defunct polyfill service has been removed.

### Status

Merging this so @snblickhan can preview on https://scribes.preview.zooniverse.org/ . Once that gets a green light, I'll deploy.